### PR TITLE
Revert codes for collision model making

### DIFF
--- a/models/darwin.l
+++ b/models/darwin.l
@@ -64,6 +64,26 @@
                       ))
                     args)
      ))
+  ;; make collision model from faces or gl-vertices
+  (:make-collision-model-for-links
+   (&key (fat 0) (collision-func 'pqp-collision-check) ((:links ls) (send self :links)))
+   (dolist (ll ls)
+     (unless (send ll :get (read-from-string (format nil ":~Amodel"
+                                                     (string-right-trim "-COLLISION-CHECK" (string collision-func)))))
+       (send ll
+             (read-from-string
+              (format nil ":make-~Amodel"
+                      (string-right-trim "-COLLISION-CHECK" (string collision-func))))
+             :fat fat
+             :faces (flatten (mapcar #'(lambda (x)
+                                         (cond
+                                          ((find-method x :def-gl-vertices)
+                                           (send (x . glvertices) :convert-to-faces :wrt :world))
+                                          (t
+                                           (send x :faces))))
+                                     (send ll :bodies)))))
+     )
+   )
   )
 
 ;; copy euscollada-body class definition from euscollada/src/euscollada-robot.l


### PR DESCRIPTION
revert codes for collision model making according to https://github.com/euslisp/jskeus/pull/93 and https://github.com/jsk-ros-pkg/jsk_model_tools/pull/46

To remove this method, we need to wait for discussion in https://github.com/jsk-ros-pkg/jsk_model_tools/issues/41.
