### PR TITLE
enable documentaiton keyword for defclass

### DIFF
--- a/lib/llib/documentation.l
+++ b/lib/llib/documentation.l
@@ -22,7 +22,7 @@
              (let (slots-str (doc-str ""))
                (dolist (slot slots)
                  (setq slots-str (concatenate string slots-str (format nil "~A " slot))))
-               (format t "~A" (escape-string (format nil "\\classdesc{~A}{~A}{~A}{}~%" (send cls :name) (send super :name) slots-str)))))
+               (format t "~A" (escape-string (format nil "\\classdesc{~A}{~A}{~A}{~A}~%" (send cls :name) (send super :name) slots-str (escape-string (documentation (send cls :name))))))))
            (write-methoddesc (method args doc)
              (let (args-str)
                (dolist (arg args)
@@ -71,9 +71,9 @@
     (setf (symbol-function 'defclass-org) (symbol-function 'defclass)))
   (unless (fboundp 'defun-org)
     (setf (symbol-function 'defun-org) (symbol-function 'defun)))
-  (defmacro defclass (cls &key super slots)
+  (defmacro defclass (cls &key super slots documentation)
     `(progn
-       (defclass-org ,cls :super ,super :slots ,slots)
+       (defclass-org ,cls :super ,super :slots ,slots :documentation ,documentation)
        (push '(make-class-document ,cls ,super '(,@slots)) *classdoc*)))
   (defmacro defun (symbol args &rest body)
     `(progn


### PR DESCRIPTION
In https://github.com/euslisp/EusLisp/blob/master/lisp/l/common.l#L742, there are :documentation keyword for make-class function and defclass is defined as macro in https://github.com/euslisp/EusLisp/blob/master/lisp/l/common.l#L821 .

but 
```
-			      documentation
-			      (doc documentation))
```
is something strange.

c.f.
documentation of class is supported in https://github.com/euslisp/EusLisp/blob/master/lisp/l/packsym.l#L78