### PR TITLE
change read-integer-array

### DIFF
--- a/lisp/l/array.l
+++ b/lisp/l/array.l
@@ -197,8 +197,7 @@
 (defun read-integer-array (strm char num)
    (let ((list (read strm t t t)))
       (if (= num 0)
-	  (fill-initial-contents (instantiate integer-vector (length list))
-				 0 (list (length list)) list)
+          (apply 'integer-vector list)
           (make-array (list-dimensions list)
 			:element-type :integer
 			:initial-contents list))))


### PR DESCRIPTION
As reported at https://github.com/euslisp/EusLisp/pull/51, read-integer-array should be changed. The function to create instance should use apply integer-vector, as the same as read-float-array.
