### PR TITLE
fix deviding bignum by float [euslisp/EusLisp/issues/62]

### DIFF
--- a/lisp/c/arith.c
+++ b/lisp/c/arith.c
@@ -836,7 +836,7 @@ bquo:
   while (i<n) {
     a=argv[i];
     if (isflt(a)) {
-      fs=big_to_float(rs); goto fquo2;}
+      fs=sign*big_to_float(rs); goto fquo2;}
     if (!isint(a)) {
       int rv = sign*div_big_big(a, rs);
       return(mkbigint(rv));


### PR DESCRIPTION
fix dividing bignum by float.
In this case,  bignum which sign have been removed is used for calculation.
https://github.com/euslisp/EusLisp/issues/62
