### PR TITLE
fix unittest

### DIFF
--- a/lib/llib/unittest.l
+++ b/lib/llib/unittest.l
@@ -198,6 +198,10 @@
   (dolist (u (send *unit-test* :functions))
     (run-test u))
   (send *unit-test* :print-result)
+  ;; exit with error status (1), if there are any failure in tests.
+  (dolist (r (send *unit-test* :result))
+    (if (/= (send r :num-failures) 0)
+        (exit 1)))
   t)
 
 (defun init-unit-test (&key log-fname)


### PR DESCRIPTION
If there are any failure in test, exit euslisp with error status from run-all-tests.
This PR relates to https://github.com/euslisp/jskeus/pull/133
