### PR TITLE
modify Eus function name float-vectorp -> float-vector-p

### DIFF
--- a/doc/jlatex/jmatrix.tex
+++ b/doc/jlatex/jmatrix.tex
@@ -16,7 +16,7 @@ float-vectorは、どんなサイズでも良い。
 前者は、呼ばれたときはいつでもベクトルが生成されるが、
 後者は読み込まれたときのみ生成される。}
 
-\funcdesc{float-vectorp}{obj}{
+\funcdesc{float-vector-p}{obj}{
 {\em obj}がfloat-vectorであるならば、Tを返す。}
 
 \funcdesc{v+}{fltvec1 fltvec2 \&optional result}{


### PR DESCRIPTION
I modified euslisp function name "float-vectorp" to "float-vector-p".
The previous function "float-vectorp" will be not correct, and the modified function "float-vector-p" will be correct.
