### PR TITLE
add examples for the elements about function matrix

### DIFF
--- a/doc/jlatex/jmatrix.tex
+++ b/doc/jlatex/jmatrix.tex
@@ -131,7 +131,8 @@ Tを返す。}
 \funcdesc{matrix}{\&rest elements}{
 {\em elements}から行列を新しく作る。
 {\tt Row x Col = (elementsの数) x (最初のelementの長さ)}
-{\em elements}は、どの型の列でもよい。
+{\em elements}は、どの型の列((list 1 2 3)や(vector 1 2 3)や
+(float-vector 1 2 3))でもよい。
 それぞれの列は行列の行ベクトルとしてならべられる。}
 
 \funcdesc{make-matrix}{rowsize columnsize \&optional init}{


### PR DESCRIPTION
I added the documents of the list-type examples for the elements about the function "matrix".
