### PR TITLE
add examples for the elements about function matrix for English

### DIFF
--- a/doc/latex/matrix.tex
+++ b/doc/latex/matrix.tex
@@ -136,7 +136,7 @@ detailed in the section \ref{Coordinates}.
 \funcdesc{matrix}{\&rest elements}{
 makes a new matrix from {\em elements}.
 Row x Col = (number of elements) x (length of the 1st element).
-Each of {\em elements} can be of any type of sequence.
+Each of {\em elements} can be of any type of sequence, for example, (list 1 2 3), (vector 1 2 3), (float-vector 1 2 3), and so on.
 Each sequence is lined up as a row vector in the matrix.}
 
 \funcdesc{make-matrix}{rowsize columnsize \&optional init}{


### PR DESCRIPTION
I added the documents of the list-type examples for the elements about the function "matrix" for English version.
