### PR TITLE
update vplus for non-3 length vector

### DIFF
--- a/lisp/geo/geopack.l
+++ b/lisp/geo/geopack.l
@@ -66,11 +66,13 @@
 
 
 (defun vplus (vertices)
+  "returns a newly created float-vector that is the sum of all the elements of vector-list. The difference from v+ is that vplus computes the sum of more than two arguments and no result vector can be specified"
    (let ((rv (instantiate float-vector  (length (car vertices)))))
       (dolist (v vertices) (v+ v rv rv))
       rv))
 
 (defun vector-mean (vertices)
+  "returns the mean vector of vector-list."
    (scale (/ 1.0 (length vertices)) (vplus vertices)))
 
 (defun direction-vector (org dest)

--- a/lisp/geo/geopack.l
+++ b/lisp/geo/geopack.l
@@ -66,7 +66,7 @@
 
 
 (defun vplus (vertices)
-   (let ((rv (float-vector 0 0 0)))
+   (let ((rv (instantiate float-vector  (length (car vertices)))))
       (dolist (v vertices) (v+ v rv rv))
       rv))
 


### PR DESCRIPTION
in euslib/jsk/jskgeo.l, we re-define as folows:
```
(defun geo::vplus (vs)
  (let ((rv (v- (car vs) (car vs))))
    (dolist (v vs rv) (v+ v rv rv))))
```

- [lisp/geo/geopack.l] add documentation for vplus/vector-mean
- [lisp/geo/geopack.l] support vplus other than 3-length vector