### PR TITLE
if euslisp is invoked with arguments, did not show any of bootstrap message

### DIFF
--- a/lib/eusrt.l
+++ b/lib/eusrt.l
@@ -70,7 +70,7 @@
 		  x::colormap))
 	(push :xwindow *features*)
 	(push :Xlib    *features*)
-	(terpri)
+	(if (null lisp::*quiet*) (terpri *error-output*))
         (when (unix:getenv "DISPLAY")
 	    (x::init-xwindow)
 	    (when  (and (unix:getenv "USE_FILEPANEL")

--- a/lisp/c/eus.c
+++ b/lisp/c/eus.c
@@ -60,6 +60,9 @@ pointer mainport;
   thread_t maintid;
 #endif
 
+int mainargc;
+char *mainargv[32];
+
 
 /****************************************************************/
 /* system defined (built-in) class index
@@ -120,7 +123,7 @@ pointer STDIN,STDOUT,ERROUT,QSTDIN,QSTDOUT,QERROUT;
 pointer QINTEGER,QFIXNUM,QFLOAT,QNUMBER;
 pointer TOPLEVEL,QEVALHOOK,ERRHANDLER,FATALERROR;
 pointer QGCHOOK, QEXITHOOK;
-pointer QUNBOUND,QDEBUG;
+pointer QUNBOUND,QDEBUG,QQUIET;
 pointer QTHREADS;	/* system:*threads* */
 pointer QPARAGC;
 pointer QVERSION;
@@ -633,6 +636,10 @@ static void initsymbols()
   QFIXNUM=intern(ctx,"FIXNUM",6,lisppkg);
   QNUMBER=intern(ctx,"NUMBER",6,lisppkg);
   QDEBUG=defvar(ctx,"*DEBUG*",NIL,lisppkg);
+  if(mainargc>1){
+    QQUIET=defvar(ctx,"*QUIET*",T,lisppkg);}
+  else{
+    QQUIET=defvar(ctx,"*QUIET*",NIL,lisppkg);}
 /*  speval(QDEBUG)=NIL; */
   PRCASE=deflocal(ctx,"*PRINT-CASE*",K_DOWNCASE,lisppkg);
   PRCIRCLE=deflocal(ctx,"*PRINT-CIRCLE*",NIL,lisppkg);
@@ -1132,7 +1139,7 @@ register context *ctx;
   eusrt=(char *)getenv("EUSRT");
   if (eusrt==NULL)  sprintf(fname,"%s/lib/eusrt.l", eusdir);
   else strcpy(fname, eusrt);
-  if (isatty(0)!=0) {
+  if (isatty(0)!=0 && speval(QQUIET) == NIL ) {
     fprintf(stderr, "configuring by \"%s\"\n", fname); }
   mkcatchframe(ctx,makeint(0), topjbuf);
   argv=makestring(fname, strlen(fname));
@@ -1141,9 +1148,6 @@ register context *ctx;
   SRCLOAD(ctx, 1, ctx->vsp-1);
   }
 
-
-int mainargc;
-char *mainargv[32];
 
 
 void mainthread(ctx)

--- a/lisp/c/memory.c
+++ b/lisp/c/memory.c
@@ -44,6 +44,7 @@ extern edata(),_end();
 static eusinteger_t top_addr, bottom_addr;
 #endif
 
+extern pointer QQUIET;
 extern pointer QPARAGC;
 extern pointer K_DISPOSE;
 
@@ -504,8 +505,9 @@ register pointer *oldsp;
   newsize=oldsize*2;
   top=oldsp-gcstack;
   newgcsp=newstack=(pointer *)malloc(newsize * sizeof(pointer)+16);
-  fprintf(stderr, "\n;; extending gcstack %p[%ld] --> %p[%ld] top=%lx\n",
-		oldstack, oldsize, newstack, newsize, top);
+  if(speval(QQUIET)==NIL){
+    fprintf(stderr, "\n;; extending gcstack %p[%ld] --> %p[%ld] top=%lx\n",
+            oldstack, oldsize, newstack, newsize, top);}
   while (stk<oldsp) *newgcsp++= *stk++;
   gcstack=newstack;
   gcsplimit= &gcstack[newsize-10];

--- a/lisp/l/eusstart.l
+++ b/lisp/l/eusstart.l
@@ -25,7 +25,7 @@
   (export '(*print-case* *print-circle* *print-object* *print-structure*
 		*print-length* *print-level*
 		*readtable* *toplevel* *read-base* *print-base*
-		*error-handler* *evalhook* *debug* *exit-on-fatal-error*
+		*error-handler* *evalhook* *debug* *quiet* *exit-on-fatal-error*
 		*unbound* *random-state* *features*
 		*package*
 		*standard-input* *standard-output*
@@ -268,17 +268,19 @@
 	  (setq func (cadr (superassoc (concatenate string "___" name)
 				system::*load-entries* nil #'equal nil))))
       (cond (func
-	      (format *error-output* ";; ~a " name)
-	      (finish-output *error-output*)
+              (when (not *quiet*)
+                (format *error-output* ";; ~a " name)
+                (finish-output *error-output*))
 	      (funcall func func)
 	      t)
 	    ((and file 
 		(eq (unix::access (concatenate string *eusdir* "lisp/" file)) T))
-		(format *error-output* ";; ~A " file)
-		(finish-output *error-output*)
+                (when (not *quiet*)
+                  (format *error-output* ";; ~A " file)
+                  (finish-output *error-output*))
 		(system::srcload (concatenate string *eusdir* "lisp/" file))
 	        t)
-	    (t (format *error-output* ";; ~a-undefined " name) nil))))
+	    (t (when (not *quiet*) (format *error-output* ";; ~a-undefined " name)) nil))))
 (defun system::exec-module-init (name &optional (file))
    (let ((func (cadr (superassoc name system::*load-entries* nil #'equal nil))))
       (if (null func)

--- a/lisp/l/loader.l
+++ b/lisp/l/loader.l
@@ -347,7 +347,7 @@
 	   (modinits (system::list-module-initializers libmod modules))
 	   (modnames))
       (dolist (m modinits)
-	(when (unix:isatty *standard-input*)
+	(when (and (unix:isatty *standard-input*) (null lisp::*quiet*))
 	  (format *error-output* "~a " (first m))
 	  (finish-output *error-output*))
 	(funcall (second m) (second m))

--- a/lisp/l/toplevel.l
+++ b/lisp/l/toplevel.l
@@ -300,8 +300,9 @@
 
 (defun eustop (&rest argv)
    (when (unix:isatty *standard-input*)
-      (warning-message 4 "~%~A" (lisp-implementation-version))
-      (terpri *error-output*) 
+      (when (null lisp::*quiet*)
+        (warning-message 4 "~%~A" (lisp-implementation-version))
+        (terpri *error-output*) )
       (unix:signal unix::sigint 'sigint-handler
 				2)	; not restart
       (unix:signal unix::sigpipe 'eussig)

--- a/lisp/xwindow/Xtop.l
+++ b/lisp/xwindow/Xtop.l
@@ -207,7 +207,7 @@
 
 (defun init-xwindow (&optional (display (unix:getenv "DISPLAY")))
  (cond ((not (zerop (setq *display* (OpenDisplay display))))
-	(if (unix:isatty *standard-input*)
+	(if (and (unix:isatty *standard-input*) (null lisp::*quiet*))
 	    (warn "connected to Xserver DISPLAY=~A~%"
 	    	 (unix:getenv "DISPLAY")))
 	;; load default fonts
@@ -329,7 +329,7 @@
 	;; initialization finished
 	(when lisp::*use-top-selector*
 	   (send *top-selector* :add-port (display-fd) #'window-main-one)
-	   (if (unix:isatty *standard-input*)
+	   (if (and (unix:isatty *standard-input*) (null lisp::*quiet*))
 	       (warn "X events are being asynchronously monitored.~%")))
 	)
        (t (warning-message 1 "Xserver connection failed"))))


### PR DESCRIPTION
this is a one of the possible solutions for #85, I found this is very difficult problem, since these message is displayed before any of euslisp repl is runnig, so we could not use normal `--option` strategy

```
k-okada@kokada-t440s:/tmp/jskeus/eus$ eusgl
configuring by "/tmp/jskeus/eus/lib/eusrt.l"
;; readmacro ;; object ;; packsym ;; common ;; constants ;; stream ;; string ;; loader ;; pprint ;; process ;; hashtab ;; array ;; mathtran ;; eusdebug ;; eusforeign ;; coordinates ;; tty ;; history ;; toplevel ;; trans ;; comp ;; builtins ;; par ;; intersection ;; geoclasses ;; geopack ;; geobody ;; primt ;; compose ;; polygon ;; viewing ;; viewport ;; viewsurface ;; hid ;; shadow ;; bodyrel ;; dda ;; helpsub ;; eushelp ;; xforeign ;; Xdecl ;; Xgraphics ;; Xcolor ;; Xeus ;; Xevent ;; Xpanel ;; Xitem ;; Xtext ;; Xmenu ;; Xscroll ;; Xcanvas ;; Xtop ;; Xapplwin 
connected to Xserver DISPLAY=:0
X events are being asynchronously monitored.
;; pixword ;; RGBHLS ;; convolve ;; piximage ;; pbmfile ;; image_correlation ;; oglforeign ;; gldecl ;; glconst ;; glforeign ;; gluconst ;; gluforeign ;; glxconst ;; glxforeign ;; eglforeign ;; eglfunc ;; glutil ;; gltexture ;; glprim ;; gleus ;; glview ;; toiv-undefined ;; fstringdouble 
EusLisp 9.10(0f0f62e) for Linux64 created on kokada-t440s(Tue Feb 17 23:06:06 JST 2015)
1.eusgl$ k-okada@kokada-t440s:/tmp/jskeus/eus$ eusgl hoge.l
1.eusgl$ 
```