### PR TITLE
[eus.c] display msg as string

### DIFF
--- a/lisp/c/eus.c
+++ b/lisp/c/eus.c
@@ -374,7 +374,7 @@ va_dcl
 	prinx(ctx,msg,ERROUT); flushstream(ERROUT); break;
     }
   if( ec == E_USER ) {
-      fprintf( stderr,"%p",msg ); flushstream(ERROUT); }
+      fprintf( stderr,"%p (%s)",msg,msg ); flushstream(ERROUT); }
   else if (ispointer(msg)) {prinx(ctx,msg,ERROUT); flushstream(ERROUT); }
   if (ctx->callfp) {
     fprintf(stderr," in ");


### PR DESCRIPTION
error codes is somtimes very hard to read,
but in this case, it calls `error` with argument such as `(error "file...")`, but did not show this message when we use height than eus1. 

```
k-okada@kokada-t440s:~/catkin_ws/ws_euslisp/src/euslisp/lisp/l$ eus0 hogee
configuring by "/home/k-okada/catkin_ws/ws_euslisp/devel/share/euslisp/jskeus/eus//lib/eusrt.l"
;; l/readmacro.l ;; l/object.l ;; l/packsym.l ;; l/common.l ;; constants ;; l/stream.l ;; l/string.l ;; l/loader.l ;; l/pprint.l ;; l/process.l ;; l/hashtab.l ;; l/array.l ;; l/mathtran.l ;; l/eusdebug.l ;; l/eusforeign.l ;; l/coordinates.l ;; l/tty.l ;; l/history.l ;; l/toplevel.l ;; comp/trans.l ;; comp/comp.l ;; comp/builtins.l ;; l/par.l ;; helpsub ;; eushelp-undefined ;; fstringdouble 
EusLisp 9.11(f542489) for Linux64 created on kokada-t440s(Fri Mar 13 15:42:33 JST 2015)
eus0: ERROR th=0  0x593e070 in (error "file ~s not found" fname)E: (exit)
k-okada@kokada-t440s:~/catkin_ws/ws_euslisp/src/euslisp/lisp/l$ eus1 hogee
configuring by "/home/k-okada/catkin_ws/ws_euslisp/devel/share/euslisp/jskeus/eus//lib/eusrt.l"
;; readmacro ;; object ;; packsym ;; common ;; constants ;; stream ;; string ;; loader ;; pprint ;; process ;; hashtab ;; array ;; mathtran ;; eusdebug ;; eusforeign ;; coordinates ;; tty ;; history ;; toplevel ;; comp/trans.l ;; comp/comp.l ;; comp/builtins.l ;; l/par.l ;; helpsub ;; eushelp ;; fstringdouble 
EusLisp 9.11(f542489) for Linux64 created on kokada-t440s(Fri Mar 13 15:42:33 JST 2015)
eus1: ERROR th=0  0x54e5f48(file #P"hogee" not found) in #<compiled-code #X5448eb8>E: (exit)
```

Another workaround is 

Assuming all E_USER message is string

```
  if( ec == E_USER ) {
      fprintf( stderr,"%s",msg ); flushstream(ERROUT); }
  else if (ispointer(msg)) {prinx(ctx,msg,ERROUT); flushstream(ERROUT); }

```

or

```
  if( ec == E_USER ) {
      fprintf( stderr,"%p",msg ); flushstream(ERROUT); }
if (ispointer(msg)) {prinx(ctx,msg,ERROUT); flushstream(ERROUT); }
```

if pointer, then print out message, even if EC == E_USER.
