### PR TITLE
Fixes for compiling on Fedora

### DIFF
--- a/lisp/Makefile.Linux
+++ b/lisp/Makefile.Linux
@@ -78,7 +78,7 @@ EUSLIB= -Xlinker  -L$(ADLIBDIR)
 GLLIB= -L$(ADLIBDIR)  -L/usr/local/lib -lGLU -lGL -lXext -leusgl
 
 # link-editor's default flags ?-rdynamic 
-SOFLAGS= -shared
+SOFLAGS= -shared -build-id
 LDFLAGS= -rdynamic
 MTOBJECTS=
 MTCOBJECTS=

--- a/lisp/Makefile.Linux.thread
+++ b/lisp/Makefile.Linux.thread
@@ -99,7 +99,7 @@ endif
 OFLAGS=-O2
 
 # link-editor's default flags ?-rdynamic 
-SOFLAGS= -shared
+SOFLAGS= -shared -build-id
 LDFLAGS= -rdynamic -fno-stack-protector -z execstack
 MTCOBJECTS= $(OBJDIR)/mthread.o $(OBJDIR)/mthread_posix.o
 #MTCOBJECTS= $(OBJDIR)/mthread.o $(OBJDIR)/pthreads.o

--- a/lisp/Makefile.Linux.thread
+++ b/lisp/Makefile.Linux.thread
@@ -83,7 +83,8 @@ RAWLIB=-ldl -lm -lpthread
 XLIB= -L/usr/X11R6/lib $(ADD_LDFLAGS) -lX11
 
 # specify directories where euslisp's libraries are located.
-EUSLIB= -Xlinker -R$(ADLIBDIR):$(EUSDIR)/lib/Linux -L$(ADLIBDIR) $(ADD_LDFLAGS)
+EUSRPATH=-R$(ADLIBDIR):$(EUSDIR)/lib/Linux
+EUSLIB= -Xlinker $(EUSRPATH) -L$(ADLIBDIR) $(ADD_LDFLAGS)
 GLLIB= -L$(ADLIBDIR) $(ADD_LDFLAGS) -lGLU -lGL -lXext -leusgl
 
 # POSIX Thread 

--- a/lisp/Makefile.Linux64
+++ b/lisp/Makefile.Linux64
@@ -82,7 +82,7 @@ THREADDEP=mthread_posix.c
 OFLAGS= -O2
 
 # link-editor's default flags ?-rdynamic 
-SOFLAGS= -shared
+SOFLAGS= -shared -build-id
 LDFLAGS= -rdynamic -fno-stack-protector -z execstack
 MTCOBJECTS= $(OBJDIR)/mthread.o $(OBJDIR)/mthread_posix.o
 #MTCOBJECTS= $(OBJDIR)/mthread.o $(OBJDIR)/pthreads.o

--- a/lisp/Makefile.Linux64
+++ b/lisp/Makefile.Linux64
@@ -71,7 +71,8 @@ RAWLIB=-ldl -lm -lpthread
 XLIB= -L/usr/X11R6/lib $(ADD_LDFLAGS) -lX11
 
 # specify directories where euslisp's libraries are located.
-EUSLIB= -Xlinker -R$(ADLIBDIR) -L$(ADLIBDIR) $(ADD_LDFLAGS)
+EUSRPATH=-R$(ADLIBDIR)
+EUSLIB= -Xlinker $(EUSRPATH) -L$(ADLIBDIR) $(ADD_LDFLAGS)
 GLLIB= -L$(ADLIBDIR) $(ADD_LDFLAGS) -lGLU -lGL -lXext -leusgl
 
 # POSIX Thread 

--- a/lisp/Makefile.LinuxARM
+++ b/lisp/Makefile.LinuxARM
@@ -94,7 +94,7 @@ THREADDEP=mthread_posix.c
 OFLAGS=-O2
 
 # link-editor's default flags ?-rdynamic 
-SOFLAGS= -shared
+SOFLAGS= -shared -build-id
 LDFLAGS= -rdynamic -fno-stack-protector -Wl,-z,execstack
 MTCOBJECTS= $(OBJDIR)/mthread.o $(OBJDIR)/mthread_posix.o
 #MTCOBJECTS= $(OBJDIR)/mthread.o $(OBJDIR)/pthreads.o

--- a/lisp/comp/comp.l
+++ b/lisp/comp/comp.l
@@ -1373,9 +1373,9 @@
 				      ((memq :sh4 *features*)
 				       "; sh4-linux-gcc -shared -o ")
 				      ((memq :ia32 *features*)
-				       "; ld -melf_i386 -shared -o ")
+				       "; ld -melf_i386 -shared -build-id -o ")
 				      (t
-				       "; ld -shared -o "))
+				       "; ld -shared -build-id -o "))
 				(namestring file.so)
 				" "
 				(namestring file.o))


### PR DESCRIPTION
Build IDs are added by default when `gcc` is used to link a binary, but not when `ld` is invoked manually. These build IDs must be present for "debuginfo" extraction during RPM compilation. I don't know for sure if the flag is used outside of Linux, so I was sure not to touch any non-Linux compile commands.

Rpaths are generally frowned upon by many packaged Linux distributions, and they are currently used by `Makefile.Linux64` for all builds. Separating the flag into its own Makefile variable allows the flag to be discarded as part of the call to `make`. The default behavior doesn't change.

Example build failure: http://csc.mcs.sdsmt.edu/jenkins/job/ros-jade-euslisp_binaryrpm_21_x86_64/3/consoleFull

Thanks,

--scott

**EDIT:** I missed `Makefile.Linux.thread` which also needed `-build-id` and the rpath change. PR updated.