### PR TITLE
[xwindow/Xtop.l] do not raise error when fonte server could not found

### DIFF
--- a/lisp/xwindow/Xtop.l
+++ b/lisp/xwindow/Xtop.l
@@ -231,6 +231,12 @@
 	(setq font-helvetica-bold-12 (font-id "*-Helvetica-Bold-R-Normal-*-12-*"))
 	(setq font-helvetica-12 (font-id "*-Helvetica-Medium-R-Normal-*-12-*"))
 	(setq font-a14 (font-id "*-fixed-medium-r-normal-*-14-*"))
+
+	(when (zerop font-cour12)  ;; this is default gc
+	  (setq *display* 0)
+	  (warning-message 1 "~%Xserver connection failed due to missing font server, please try after computer restarts~%")
+	  (return-from init-xwindow))
+
 	(setq *screen-no* (defaultscreen *display*))
 	(setq *screen* (defaultscreenofdisplay *display*))
 	(setq *visual* (defaultvisualofscreen *screen*))


### PR DESCRIPTION
this is workaround for the trouble when you use euslisp first time installed on the computer
```
decl ;; Xgraphics ;; Xcolor ;; Xeus ;; Xevent ;; Xpanel ;; Xitem ;; Xtext ;; Xmenu ;; Xscroll ;; Xcanvas ;; Xtop ;; Xapplwin 
connected to Xserver DISPLAY=:0
can't load font "*-courier-medium-r-*-8-*"can't load font "*-courier-medium-r-*-10-*"can't load font "*-courier-medium-r-*-12-*"can't load font "*-courier-medium-r-*-14-*"can't load font "*-courier-medium-r-*-18-*"can't load font "*-courier-bold-r-*-12-*"can't load font "*-courier-bold-r-*-14-*"can't load font "*-courier-bold-r-*-18-*"can't load font "*-courier-bold-r-*-24-*"can't load font "*-times-medium-r-*-10-*"can't load font "*-times-medium-r-*-12-*"can't load font "*-times-bold-r-*-12-*"can't load font "*-times-bold-r-*-14-*"can't load font "*-times-bold-r-*-18-*"can't load font "*-times-bold-r-*-24-*"can't load font "lucidasans-bold-12"can't load font "lucidasans-bold-14"can't load font "*-Helvetica-Bold-R-Normal-*-12-*"can't load font "*-Helvetica-Medium-R-Normal-*-12-*"X Error of failed request:  BadFont (invalid Font parameter)
  Major opcode of failed request:  56 (X_ChangeGC)
  Resource id in failed request:  0x0
  Serial number of failed request:  49
  Current serial number in output stream:  58
``