### PR TITLE
[lisp/l/eusdebug.l] change assert API, message is optional

### DIFF
--- a/lisp/l/eusdebug.l
+++ b/lisp/l/eusdebug.l
@@ -23,7 +23,7 @@
 	*remote-port*
 	remote-error reval *server-streams* remote-port))
 
-(defmacro assert (pred message &rest args)
+(defmacro assert (pred &optional (message "") &rest args)
     `(while (not ,pred)
 	(format *error-output* ,message ,@args)
         (finish-output *error-output*)


### PR DESCRIPTION
(assert) is also defined in lib/llib/unittest.l and that interface is defined as

` (defmacro assert (pred &optional (message "") &rest args)`

this change fixes assert in eusdebug.l to match this API.

Original Common lisp definision of assert is

```
[Macro]
assert test-form [({place}*) [string {arg}*]]

old_change_begin
assert signals an error if the value of test-form is nil. Continuing from this error will allow the user to alter the values of some variables, and assert will then start over, evaluating test-form again. assert returns nil.

test-form is any form. Each place (there may be any number of them, or none) must be a generalized-variable reference acceptable to setf. These should be variables on which test-form depends, whose values may sensibly be changed by the user in attempting to correct the error. Subforms of each place are only evaluated if an error is signaled, and may be re-evaluated if the error is re-signaled (after continuing without actually fixing the problem).

The string is an error message string, and the args are additional arguments; they are evaluated only if an error is signaled, and re-evaluated if the error is signaled again. The function format is applied in the usual way to string and args to produce the actual error message. If string is omitted (and therefore also the args), a default error message is used. 
old_change_end

Implementation note: The debugger need not include the test-form in the error message, and the places should not be included in the message, but they should be made available for the user's perusal. If the user gives the ``continue'' command, he should be presented with the opportunity to alter the values of any or all of the references. The details of this depend on the implementation's style of user interface, of course.
change_begin
X3J13 voted in June 1988 (CONDITION-SYSTEM)   to adopt a proposal for a Common Lisp Condition System. This proposal modifies the definition of assert to specify its interaction with the condition system. See section 29.4.2.

X3J13 voted in March 1988 (PUSH-EVALUATION-ORDER)   to clarify order of evaluation (see section 7.2).

X3J13 voted in June 1989 (SETF-MULTIPLE-STORE-VARIABLES)   to extend the specification of assert to allow a place whose setf method has more than one store variable (see define-setf-method). 
change_end

Examples:

(assert (valve-closed-p v1)) 

(assert (valve-closed-p v1) () 
        "Live steam is escaping!") 

(assert (valve-closed-p v1) 
        ((valve-manual-control v1)) 
        "Live steam is escaping!") 

;; Note here that the user is invited to change BASE,  
;; but not the bounds MINBASE and MAXBASE. 


(assert (<= minbase base maxbase) 
        (base) 
        "Base ~D is not in the range ~D, ~D" 
        base minbase maxbase) 

;; Note here that it is probably not desirable to include the 
;; entire contents of the two matrices in the error message. 
;; It is reasonable to assume that the debugger will give 
;; the user access to the values of the places A and B. 

(assert (= (array-dimension a 1)  
           (array-dimension b 0)) 
        (a b) 
        "Cannot multiply a ~D-by-~D matrix ~ 
         and a ~D-by-~D matrix." 
        (array-dimension a 0) 
        (array-dimension a 1) 
        (array-dimension b 0) 
        (array-dimension b 1))

```
https://www.cs.cmu.edu/Groups/AI/html/cltl/clm/node221.html#SPECIALIZEDERRORSIGNALLING