### PR TITLE
add argument to defun

### DIFF
--- a/lisp/c/eus.h
+++ b/lisp/c/eus.h
@@ -1063,7 +1063,7 @@ extern pointer makemodule(context *, int);
 extern pointer makebig1(long);
 extern pointer eusfloat_to_big(float);
 extern eusfloat_t big_to_float(pointer);
-extern pointer defun(context *, char *, pointer, pointer(*)());
+extern pointer defun(context *, char *, pointer, pointer(*)(), char *);
 extern pointer defmacro(context *, char *, pointer, pointer(*)());
 extern pointer defspecial(context *, char *, pointer, pointer(*)());
 extern pointer defunpkg(context *, char *, pointer, pointer(*)(),pointer);
@@ -1075,6 +1075,8 @@ extern pointer deflocal(context *, char *, pointer, pointer);
 extern pointer defconst(context *, char *, pointer, pointer);
 extern pointer stacknlist(context *, int);
 #endif
+/* for old style defun */
+#define defun(a, b, c, d) defun(a, b, c, d, NULL)
 
 #if THREADED
 extern pointer makethreadport(context *);

--- a/lisp/c/eus_proto.h
+++ b/lisp/c/eus_proto.h
@@ -344,7 +344,7 @@ extern pointer makeratio(int /*num*/, int /*denom*/);
 extern pointer makebig(int /*n*/);
 extern pointer makebig1(long /*x*/);
 extern pointer makebig2(long /*hi*/, long /*lo*/);
-extern pointer defun(context */*ctx*/, char */*name*/, pointer /*mod*/, pointer (*/*f*/)());
+extern pointer defun(context */*ctx*/, char */*name*/, pointer /*mod*/, pointer (*/*f*/)(), char * /*doc*/);
 extern pointer defunpkg(context */*ctx*/, char */*name*/, pointer /*mod*/, pointer (*/*f*/)(), pointer /*pkg*/);
 extern pointer defmacro(context */*ctx*/, char */*name*/, pointer /*mod*/, pointer (*/*f*/)());
 extern int special_index(void);

--- a/lisp/c/makes.c
+++ b/lisp/c/makes.c
@@ -603,13 +603,14 @@ long hi, lo;
 /****************************************************************/
 /* defines
 /****************************************************************/
-
-pointer defun(ctx,name,mod,f)
+#undef defun /* remove macro for reading correct defun */
+pointer defun(ctx,name,mod,f,doc)
 register context *ctx;
 char *name;
 pointer mod;
 pointer (*f)();
-{ register pointer sym,pkg;
+char *doc;
+{ register pointer sym,pkg,pdoc;
 #if defined(DEFUN_DEBUG) || defined(DEBUG_COUNT)
   static int count=0;
 
@@ -621,11 +622,18 @@ pointer (*f)();
 
   pkg=Spevalof(PACKAGE);
   sym=intern(ctx,name,strlen(name),pkg);
-  pointer_update(sym->c.sym.spefunc,makecode(mod,f,SUBR_FUNCTION));
+  if (doc != NULL) {
+    pdoc = makestring(doc,strlen(doc));
+    vpush(pdoc);
+  }
+  compfun(ctx, sym, mod, f, pdoc);
+  if (doc != NULL) vpop();
 #ifdef DEFUN_DEBUG
   printf( "0x%lx\n", sym->c.sym.spefunc->c.code.entry );
 #endif
   return(sym);}
+/* restore macro */
+#define defun(a, b, c, d) defun(a, b, c, d, NULL)
 
 pointer defunpkg(ctx,name,mod,f,pkg)
 register context *ctx;


### PR DESCRIPTION
add argument to defun for adding documentation string to functions written by C
This is another implementation of
https://github.com/euslisp/EusLisp/pull/111

for using variable arguments we must know number of arguments.
