### PR TITLE
[isp/l/common.l] support multiple argument at function `/=`

### DIFF
--- a/doc/jlatex/jarith.tex
+++ b/doc/jlatex/jarith.tex
@@ -41,21 +41,37 @@
 \funcdesc{evenp}{integer}{
 {\em integer}が偶数のとき、Tを返す。引数は{\tt integer}のみ有効。}
 
-\funcdesc{/=}{num1 num2}{
-{\em num1}が{\em num2}と等しくないとき、Tを返す。
-{\em num1}と{\em num2}は数値であること。}
+\funcdesc{/=}{num1 num2 \&rest more-numbers}{
+{\em num1}と{\em num2}、{\em more-numbers}でどの2つの数値も等しくないとき、Tを返す。それ以外はNILを返す。
+{\em num1}と{\em num2}、{\em more-numbers}を構成する要素はすべて数値であること。}
 
 \funcdesc{=}{num1 num2 \&rest more-numbers}{
-{\em num1}と{\em num2}等しいときを、T返す。
-{\em num1}と{\em num2}は数値であること。}
+{\em num1}と{\em num2}、{\em more-numbers}がすべて等しいとき、Tを返す。
+{\em num1}と{\em num2}、{\em more-numbers}を構成する要素はすべて数値であること。}
 
-\fundesc{$>$}{num1 num2 \&rest more-numbers}
-\fundesc{$<$}{num1 num2 \&rest more-numbers}
-\fundesc{$>=$}{num1 num2 \&rest more-numbers}
+\funcdesc{$>$}{num1 num2 \&rest more-numbers}{
+{\em num1}、{\em num2}、{\em more-numbers}の全要素がこの順に単調減少であるとき、Tを返す。
+{\em num1}と{\em num2}、{\em more-numbers}を構成する要素はすべて数値であること。
+誤差を含めた数値比較に対しては、
+\ref{Geometry}章に書かれている関数（{\bf eps$>$}）を使用する。}
+
+\funcdesc{$<$}{num1 num2 \&rest more-numbers}{
+{\em num1}、{\em num2}、{\em more-numbers}の全要素がこの順に単調増加であるとき、Tを返す。
+{\em num1}と{\em num2}、{\em more-numbers}を構成する要素はすべて数値であること。
+誤差を含めた数値比較に対しては、
+\ref{Geometry}章に書かれている関数（{\bf eps$<$}）を使用する。}
+
+\funcdesc{$>=$}{num1 num2 \&rest more-numbers}{
+{\em num1}、{\em num2}、{\em more-numbers}の全要素がこの順に単調非増加であるとき、Tを返す。
+{\em num1}と{\em num2}、{\em more-numbers}を構成する要素はすべて数値であること。
+誤差を含めた数値比較に対しては、
+\ref{Geometry}章に書かれている関数（{\bf eps$>=$}）を使用する。}
+
 \funcdesc{$<=$}{num1 num2 \&rest more-numbers}{
-これらの比較演算は、数値のみ適用できる。誤差を含めた数値比較に対しては、
-\ref{Geometry}章に書かれている関数（これらの比較演算子の前に{\bf eps}が
-ついている）を使用する。}
+{\em num1}、{\em num2}、{\em more-numbers}の全要素がこの順に単調非減少であるとき、Tを返す。
+{\em num1}と{\em num2}、{\em more-numbers}を構成する要素はすべて数値であること。
+誤差を含めた数値比較に対しては、
+\ref{Geometry}章に書かれている関数（{\bf eps$<=$}）を使用する。}
 \end{refdesc}
 
 \subsection{整数とビット毎の操作関数}

--- a/doc/latex/arith.tex
+++ b/doc/latex/arith.tex
@@ -44,19 +44,35 @@ T if {\em integer} is odd.}
 The argument must be an integer.
 T if {\em integer} is an even number.}
 
-\funcdesc{/=}{n1 n2}{
-Both {\em n1} and {\em n2} must be numbers.
-T if {\em n1} is not equal to {\em n2}.}
+\funcdesc{/=}{n1 n2 \&rest more-numbers}{
+Both {\em n1}, {\em n2} and all elements of {\em more-numbers} must be numbers.
+T if no two of its arguments are numerically equal, NIL otherwise.}
 
 \funcdesc{=}{num1 num2 \&rest more-numbers}{
-Both {\em n1} and {\em n2} must be numbers.
-T if {\em n1} is equal to {\em n2}.}
+Both {\em n1} and {\em n2} and all elements of {\em more-numbers} must be numbers.
+T if {\em n1}, {\em n2} and all elements of {\em more-numbers} are the same in value, NIL otherwise.}
 
-\fundesc{$>$}{num1 num2 \&rest more-numbers}
-\fundesc{$<$}{num1 num2 \&rest more-numbers}
-\fundesc{$>=$}{num1 num2 \&rest more-numbers}
+\funcdesc{$>$}{num1 num2 \&rest more-numbers}{
+Both {\em n1} and {\em n2} and all elements of {\em more-numbers} must be numbers.
+T if {\em n1}, {\em n2} and all elements of {\em more-numbers} are in monotonically decreasing order, NIL otherwise.
+For numerical comparisons with tolerance, use functions prefixed
+by {\bf eps} as described in the section \ref{Geometry}.}
+
+\funcdesc{$<$}{num1 num2 \&rest more-numbers}{
+Both {\em n1} and {\em n2} and all elements of {\em more-numbers} must be numbers.
+T if {\em n1}, {\em n2} and all elements of {\em more-numbers} are in monotonically increasing order, NIL otherwise.
+For numerical comparisons with tolerance, use functions prefixed
+by {\bf eps} as described in the section \ref{Geometry}.}
+
+\funcdesc{$>=$}{num1 num2 \&rest more-numbers}{
+Both {\em n1} and {\em n2} and all elements of {\em more-numbers} must be numbers.
+T if {\em n1}, {\em n2} and all elements of {\em more-numbers} are in monotonically nonincreasing order, NIL otherwise.
+For numerical comparisons with tolerance, use functions prefixed
+by {\bf eps} as described in the section \ref{Geometry}.}
+
 \funcdesc{$<=$}{num1 num2 \&rest more-numbers}{
-These comparisons can only be applicable to numbers.
+Both {\em n1} and {\em n2} and all elements of {\em more-numbers} must be numbers.
+T if {\em n1}, {\em n2} and all elements of {\em more-numbers} are in monotonically nondecreasing order, NIL otherwise.
 For numerical comparisons with tolerance, use functions prefixed
 by {\bf eps} as described in the section \ref{Geometry}.}
 \end{refdesc}

--- a/lisp/c/arith.c
+++ b/lisp/c/arith.c
@@ -82,6 +82,23 @@ flteqnum:
       return(T); }
   else error(E_NONUMBER);}
 
+pointer NUMNEQUAL(ctx,n,argv)
+register context *ctx;
+register int n;
+register pointer argv[];
+{ register i;
+  pointer cmparr[2];
+  numunion nu;
+
+  if (n<=1) error(E_MISMATCHARG);
+  while(--n>=0) {
+    cmparr[0] = argv[n];
+    for(i=0;i<n;++i){
+      cmparr[1]=argv[i];
+      if((NIL) != NUMEQUAL(ctx,2,cmparr))
+        return(NIL);}}
+  return(T);
+}
 
 pointer GREATERP(ctx,n,argv)
 register context *ctx;
@@ -1418,6 +1435,7 @@ register context *ctx;
 pointer mod;
 {
   defun(ctx,"=",mod,NUMEQUAL);
+  defun(ctx,"/=",mod,NUMNEQUAL);
   defun(ctx,">",mod,GREATERP);
   defun(ctx,"<",mod,LESSP);
   defun(ctx,">=",mod,GREQP);

--- a/lisp/l/common.l
+++ b/lisp/l/common.l
@@ -925,7 +925,6 @@ if pos is bigger than the length of list, item is nconc'ed at the tail"
 (defun minusp (n) (< n 0))
 (defun oddp (n) (logbitp 0 n))
 (defun evenp (n) (not (logbitp 0 n)))
-(defun /= (n1 n2) (not (= n1 n2)))
 (defun logandc1 (x y) (logand (lognot x) y))
 (defun logandc2 (x y) (logand x (lognot y)))
 (defmacro ecase (&rest x) (cons 'case x))


### PR DESCRIPTION
in common lisp

```lisp
(/= 1 2 3) => t
```

in euslisp, if argument size is more than 3, it fails.