### PR TITLE
Release version 9.15

### DIFF
--- a/doc/HISTORY
+++ b/doc/HISTORY
@@ -527,3 +527,8 @@
          lisp/l/packsym.l raise error when intsymvector is full, which previouusly go into infinite loop
 2015-Jun ; version 9.14
          fix assert API. Now message is optional (defmacro assert (pred &optional message)
+2015-Aug ; version 9.15
+         fix char comparison function (previous version retuns opossite result)
+         support multiple argument at function /=
+         add url encode feature (escape-url function)
+         support microsecond add/subtract in interval-time class

--- a/doc/jlatex/jintro.tex
+++ b/doc/jlatex/jintro.tex
@@ -207,6 +207,7 @@ Euslispのオーガナイズドセッションが開かれた。
 \item[2015] ARMサポートが追加された．バージョンが9.12となった．
             class documentationが追加された．バージョンが9.13となった．
             assert 関数のAPIが変更された．message がオプションになった (defmacro assert (pred \&optional message)．バージョンが9.14となった．
+            文字比較関数の結果の誤りを修正した, /=関数で複数引数をサポートした, URLエンコード関数(escape-url）を追加した, interval-timeクラスの加減算でマイクロ秒をサポートした．バージョンが9.15となった．
 \end{description}
 
 \subsection{インストール}

--- a/doc/jlatex/jmanual.tex
+++ b/doc/jlatex/jmanual.tex
@@ -10,7 +10,7 @@
 \AtBeginDvi{\special{pdf:tounicode 90ms-RKSJ-UCS2}}\fi
 
 %%%
-\newcommand{\eusversion}{9.14}
+\newcommand{\eusversion}{9.15}
 
 
 \flushbottom

--- a/doc/latex/intro.tex
+++ b/doc/latex/intro.tex
@@ -279,6 +279,7 @@ in Fukuoka.
 \item[2015] Version 9.12 is released, support ARM
             Version 9.13 is released, support class documentation
             Version 9.14 is released, fix assert API. Now message is optional (defmacro assert (pred \&optional message)
+            Version 9.15 is released, fix char comparison function (previous version retuns opossite result), support multiple argument at function /=,  add url encode feature (escape-url function), support microsecond add/subtract in interval-time class
 \end{description}
 
 \subsection{Installation}

--- a/doc/latex/manual.tex
+++ b/doc/latex/manual.tex
@@ -8,7 +8,7 @@
 \usepackage[dvipdfmx,bookmarks=true,bookmarksnumbered=true,bookmarkstype=toc]{hyperref}
 
 %%%
-\newcommand{\eusversion}{9.14}
+\newcommand{\eusversion}{9.15}
 
 \flushbottom
 \makeindex


### PR DESCRIPTION
this includes

lisp::char< and lisp::char> are opposite?  https://github.com/euslisp/EusLisp/issues/122

[lisp/l/string.l] add url encode feature #125

[lib/llib/time.l] support add/subtract including microseconds #128

[lisp/l/common.l] support multiple argument at function `/=` #124



