### PR TITLE
[lib/llib/unittest.l] add trace option to init-unit-test

### DIFF
--- a/lib/llib/unittest.l
+++ b/lib/llib/unittest.l
@@ -206,7 +206,7 @@
         (exit 1)))
   t)
 
-(defun init-unit-test (&key log-fname)
+(defun init-unit-test (&key log-fname trace)
   (let* ((p "--gtest_output=xml:")
          (s (find-if #'(lambda (tmpx) (substringp p tmpx)) lisp::*eustop-argument*))
          (xml-fname (if s (string-left-trim p s))))
@@ -218,6 +218,13 @@
     (unix:signal unix::sighup 'unittest-sigint-handler)
 
     (setq *unit-test* (instance unit-test-container :init :log-fname log-fname))
+
+    (when trace
+      (setf (symbol-function 'defun-org) (symbol-function 'defun))
+      (defmacro defun (name args &rest body)
+        `(prog1
+           (defun-org ,name ,args ,@body)
+           (trace ,name))))
 
     (defmacro assert (pred &optional (message "") &rest args)
       (with-gensyms


### PR DESCRIPTION
With trace option, we can inspect function calling, arguments, and return values.

```lisp
$ rostest jsk_2013_04_pr2_610 test-demo.test -t
start testing [test-demo]
1: --> test-demo nil;;
2: --> demo nil;;
3: --> speak-jp ("部屋の掃除を始めます");;
4: --> send-speak-msg (#<sound_play::soundrequest #X681b788> :topic-name "robotsound_jp" :wait nil :timeout 20);;
4: t <-- send-speak-msg;;
3: t <-- speak-jp;;
3: --> setup nil;;
```

**NOTE**

It is recommended to use `require` instead of load in codes.

```lisp
;; THIS MAY DISPLAY HUGE TRACE LOGS
(init-unit-test :trace t)
(load "package://jsk_2013_04_pr2_610/euslisp/demo.l")
```

If all `load`ing are written after `(init-unit-test)`, trace log may be huge and redundant in test.

```lisp
;; BETTER
(require :pr2-interface "package://pr2eus/pr2-interface.l")
(init-unit-test :trace t)
(load "package://jsk_2013_04_pr2_610/euslisp/demo.l")
```

By loading basic components before `(init-unit-test)`, we can enable tracing only relevant functions.