### PR TITLE
lisp/opengl/src/util.c: gluTessCallbackl() use fn2 for on 4-byte alignment libraries

### DIFF
--- a/lisp/opengl/src/glforeign.l
+++ b/lisp/opengl/src/glforeign.l
@@ -348,6 +348,14 @@
         (symbol-function 'glGetMaterialfv))
   (setf (symbol-function 'glMaterialfv-org)
         (symbol-function 'glMaterialfv))
+  ;; #if GL_EXT_texture_object && !Darwin
+  (if (not (fboundp 'glGenTexturesEXT))
+      (setf (symbol-function 'glGenTexturesEXT)
+	    (symbol-function 'glGenTextures)))
+  (if (not (fboundp 'glBindTextureEXT))
+      (setf (symbol-function 'glBindTextureEXT)
+	    (symbol-function 'glBindTexture)))
+  ;; #endif  GL_EXT_texture_object && !Darwin
   (if (fboundp 'glGenTexturesEXT)
       (setf (symbol-function 'glGenTexturesEXT-org)
 	    (symbol-function 'glGenTexturesEXT)))

--- a/lisp/opengl/src/oglforeign.c.c
+++ b/lisp/opengl/src/oglforeign.c.c
@@ -596,9 +596,12 @@ pointer argv[];
   defoglforeign(ctx,"gluTessBeginPolygon");
   defoglforeign(ctx,"gluTessEndPolygon");
 
-#if GL_EXT_texture_object
+#if GL_EXT_texture_object && !Darwin
   defoglforeign(ctx,"glGenTexturesEXT");
   defoglforeign(ctx,"glBindTextureEXT");
+#else
+  defoglforeign(ctx,"glGenTextures");
+  defoglforeign(ctx,"glBindTexture");
 #endif
 #if 0 /* GL_EXT_polygon_offset */
   defoglforeign(ctx,"glPolygonOffsetEXT");

--- a/lisp/opengl/src/util.c
+++ b/lisp/opengl/src/util.c
@@ -82,13 +82,16 @@ void gluLookAtfv(v)
 	    (GLdouble)v[6], (GLdouble)v[7], (GLdouble)v[8]);
 }
 
-void gluTessCallbackl(tobj, which, fn)
+void gluTessCallbackl(tobj, which, fn, fn2)
   eusinteger_t *tobj;
   eusinteger_t which;
   eusinteger_t fn;
+  eusinteger_t fn2;
 {
+  eusinteger_t addr = fn << 2;
+  if ( fn2 != 0 ) addr = addr | (fn2 & 0x0000ffff);
   gluTessCallback((GLUtriangulatorObj *)tobj, (GLenum)which,
-		  (void (*)()) ( (fn << 2)));
+		  (void (*)()) ( addr ));
 }
 
 void glClearAccumfv(v)


### PR DESCRIPTION
### lisp/opengl/src/util.c: gluTessCallbackl() use fn2 for on 4-byte alignment libraries

this is originally supported at https://github.com/euslisp/EusLisp/commit/2a1b2cc32b2a17635bbf3f8f383f060b3c67a84d
but reverted at https://github.com/euslisp/EusLisp/commit/af60bd8ab427b3a233ba7e48f96d2c5d10caed4a