### PR TITLE
[lisp/l/hashtab.l] fix trim method in queue class

### DIFF
--- a/lisp/l/hashtab.l
+++ b/lisp/l/hashtab.l
@@ -221,7 +221,7 @@
  (:length () (length car))
  (:empty? () (null car))
  (:trim (s) ;; discard old entries to keep the size of this queue to 's'
-     (dotimes (i (- s (length car))) (send self :dequeue)))
+     (dotimes (i (- (length car) s)) (send self :dequeue)))
  (:dequeue (&optional (error-p nil))
      (cond ((null car)
 		(if error-p


### PR DESCRIPTION
`send qq :trim s`で`s`が`(car qq)`より短いときに、`(car qq)`の長さを`s`まで縮めるようにしました。
```
(setq qq (instance queue :init))
(dotimes (i 5) (send qq :enqueue i))
(car qq) ;;return (0 1 2 3 4)
(send qq :trim 3)
(car qq) ;;return (2 3 4)
(send qq :trim 6)
(car qq);;return (2 3 4)
```
