### PR TITLE
[latex/intro.tex,jlatex/jintro.tex] Use \_ instead of _ in tex

### DIFF
--- a/doc/jlatex/jintro.tex
+++ b/doc/jlatex/jintro.tex
@@ -211,7 +211,7 @@ Euslispのオーガナイズドセッションが開かれた。
             make-random-state関数が追加された, lib/llib/unittest.lのバグ修正．バージョンが9.16となった．
 \item[2016] init-unit-testにtraceオプションを追加した．\#f(nan inf)をロードできるようにした．models/docの更新修正．バージョンが9.17となった．
             gcc-5対応を行った．バージョンが9.18となった．
-            aarm64(ARM)対応を行った．バージョンが9.19となった． OSX対応を行った (gluTessCallback, glGenTexturesEXT), GL_COLOR_ATTACHMENT 定数の追加, color-image クラスの修正 (BGR から RGB へ修正）．バージョンが9.20となった．
+            aarm64(ARM)対応を行った．バージョンが9.19となった． OSX対応を行った (gluTessCallback, glGenTexturesEXT), GL\_COLOR\_ATTACHMENT 定数の追加, color-image クラスの修正 (BGR から RGB へ修正）．バージョンが9.20となった．
 \end{description}
 
 \subsection{インストール}

--- a/doc/latex/intro.tex
+++ b/doc/latex/intro.tex
@@ -283,7 +283,7 @@ in Fukuoka.
             Version 9.16 is released, added make-random-state, fixed bug in lib/llib/unittest.l
 \item[2016] Version 9.17 is released, add trace option in (init-unit-test), enable to read \#f(nan inf)．fix models/doc.
             Version 9.18 is released, support gcc-5.
-            Version 9.20 is released, support OSX (gluTessCallback, glGenTexturesEXT), add GL_COLOR_ATTACHMENT constants, fix color-image class, (it uses RGB not BGR).
+            Version 9.20 is released, support OSX (gluTessCallback, glGenTexturesEXT), add GL\_COLOR\_ATTACHMENT constants, fix color-image class, (it uses RGB not BGR).
 \end{description}
 
 \subsection{Installation}


### PR DESCRIPTION
[latex/intro.tex,jlatex/jintro.tex] Use \_ instead of _ in tex.
Fix bug of https://github.com/euslisp/EusLisp/commit/211276521321fac26b8e813d9109a1492a73bd92.
Checked `make` of latex and jlatex on my PC.