### PR TITLE
[doc/jlatex, doc/latex] add descriptions of coordinate class to manual

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -37,6 +37,7 @@ fi
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
 
     travis_time_start setup.install
+    brew tap homebrew/x11
     brew install jpeg libpng mesalib-glw wget;
     travis_time_end
 

--- a/doc/jlatex/jmanual.tex
+++ b/doc/jlatex/jmanual.tex
@@ -2,7 +2,7 @@
 
 %%% added 2004.12.14
 \documentclass[]{jarticle}
-\usepackage{makeidx,mytabbing,fancyheadings}
+\usepackage{makeidx,mytabbing,fancyheadings,amsmath}
 \usepackage[dvipdfmx]{graphicx,color,epsfig}
 \let\epsfile=\epsfig
 \usepackage[dvipdfmx,bookmarks=true,bookmarksnumbered=true,bookmarkstype=toc]{hyperref}

--- a/doc/jlatex/jmatrix.tex
+++ b/doc/jlatex/jmatrix.tex
@@ -527,3 +527,165 @@ Euslisp内で座標系は、高速性と一般性のために
 \end{refdesc}
 
 \newpage
+\subsection{変換行列とcoordinates classとの関係}
+
+\noindent
+変換行列Tを$4\times4$の同次行列表現として以下のように表したした時の、
+coordinatesとの関係を説明する。
+\[
+T = \begin{pmatrix}
+\mathbf{R}_T & \mathbf{p}_T \\
+\mathbf{0} & 1
+\end{pmatrix}
+\]
+
+$\mathbf{R}_T$は$3\times3$行列、$\mathbf{p}_T$は$3\times1$行列(eus内部処理
+では要素数3のfloat-vector)であって、
+EusLispにおけるcoordinatesクラスは$\mathbf{R}$は$3\times3$ の回転行列と
+3 次元位置ベクトルの組で表現されており、
+スロット変数のrotとposは、それぞれ、$\mathbf{R}_T$、$\mathbf{p}_T$に対応する。
+
+\vspace{1ex}
+\noindent {\underline {\bf {\gt 回転行列と３次元位置の取り出し}}}
+
+\noindent
+coordinates classのメソッドを用いて、以下のように$\mathbf{R}$と$\mathbf{p}$を取り出せる。
+
+\noindent
+以下、Tはcoordinateクラスのインスタンスである。
+
+\noindent
+(send T :rot)
+
+$\Rightarrow$ $\mathbf{R}_T$
+
+\noindent
+(send T :pos)
+
+$\Rightarrow$ $\mathbf{p}_T$
+
+\vspace{1ex}
+\noindent {\underline {\bf {\gt ベクトルを変換するメソッド}}}
+
+\noindent
+以下、$\mathbf{v}$は3次元ベクトルである。
+
+\noindent
+(send T :rotate-vector $\mathbf{v}$)
+
+$\Rightarrow$  $\mathbf{R}_T \mathbf{v}$
+
+\noindent
+(send T :inverse-rotate-vector $\mathbf{v}$)
+
+$\Rightarrow$ $\mathbf{v}^T \mathbf{R}_T$
+
+\noindent
+(send T :transform-vector $\mathbf{v}$)
+
+$\Rightarrow$ $\mathbf{R}_T\mathbf{v} + \mathbf{p}_T$
+
+ローカル座標系Tで表されたベクトルをワールド座標系で表されたベクトルに変換する
+
+\noindent
+(send T :inverse-transform-vector $\mathbf{v}$)
+
+$\Rightarrow$ $\mathbf{R}_T^{-1}\left( \mathbf{v} - \mathbf{p}_T \right)$
+
+ワールド座標系で表されたベクトルをローカル座標系Tで表されたベクトルに変換する
+
+\vspace{1ex}
+\noindent {\underline {\bf {\gt 座標系を返すメソッド (座標系を変更しない)}}}
+
+\noindent
+(send T :inverse-transformation)
+
+$\Rightarrow$ $T^{-1}$
+
+逆行列を返す。\[
+T^{-1} = \begin{pmatrix}
+ \mathbf{R}_T^{-1} & -\mathbf{R}_T^{-1}\mathbf{p}_T \\
+ \mathbf{0} & 1
+\end{pmatrix}
+\]
+
+\noindent
+(send T :transformation A (\&optional (wrt :local)))
+
+wrt == :local のとき、$T^{-1}A$ を返す
+
+wrt == :world のとき、$AT^{-1}$ を返す
+
+wrt == W (coordinates class) のとき、$W^{-1}AT^{-1}W$ を返す
+
+
+\vspace{1ex}
+\noindent {\underline {\bf {\gt 座標系を変更するメソッド}}}
+
+\noindent
+以下、A は coordinatesクラスのインスタンスである。
+
+\noindent
+$\Leftrightarrow$ はスロット変数と与えられたインスタンス（行列またはベクトル）が同一になることを表す。
+一方の変更が、他方の変更に反映されるため、注意して使用すること。
+
+\noindent
+$\leftarrow$ は代入を表す。
+
+\noindent
+(send T :newcoords A)
+
+$\mathbf{R}_T \Leftrightarrow \mathbf{R}_A$
+
+$\mathbf{p}_T \Leftrightarrow \mathbf{p}_A$
+
+\noindent
+(send T :newcoords $\mathbf{R}$ $\mathbf{p}$)
+
+$\mathbf{R}_T \Leftrightarrow \mathbf{R}$
+
+$\mathbf{p}_T \Leftrightarrow \mathbf{p}$
+
+\noindent
+(send T :move-to A (\&optional (wrt :local)))
+
+wrt == :local のとき、$T \leftarrow TA$
+
+wrt == :world のとき、$T \Leftrightarrow A$
+
+wrt == W (coordinates class) のとき、$T \leftarrow WA$
+
+\noindent
+(send T :translate $\mathbf{v}$ (\&optional (wrt :local)))
+
+wrt == :local のとき、
+$\mathbf{p}_{T} \leftarrow \mathbf{p}_{T} + \mathbf{R}_{T}\mathbf{v}$
+
+wrt == :world のとき、
+$\mathbf{p}_{T} \leftarrow \mathbf{p}_{T} + \mathbf{v}$
+
+wrt == W (coordinates class) のとき、
+$\mathbf{p}_{T} \leftarrow \mathbf{p}_{T} + \mathbf{R}_{W}\mathbf{v}$
+
+\noindent
+(send T :locate $\mathbf{v}$ (\&optional (wrt :local)))
+
+wrt == :local のとき、
+$\mathbf{p}_{T} \leftarrow \mathbf{p}_{T} + \mathbf{R}_{T} \mathbf{v}$
+
+wrt == :world のとき、
+$\mathbf{p}_{T} \leftarrow \mathbf{v}$
+
+wrt == W (coordinates class) のとき、
+$\mathbf{p}_{T} \leftarrow \mathbf{p}_{W} + \mathbf{R}_{W}\mathbf{v}$
+
+\noindent
+(send T :transform A (\&optional (wrt :local)))
+
+wrt == :local のとき、 $T \leftarrow TA$
+
+wrt == :world のとき、 $T \leftarrow AT$
+
+wrt == W (coordinates class) のとき、$T \leftarrow$ $\left( WAW \right)^{-1} T$
+
+\newpage

--- a/doc/latex/manual.tex
+++ b/doc/latex/manual.tex
@@ -2,7 +2,7 @@
 
 %%% added from jmanual.tex 2004.12.14
 \documentclass[a4paper]{article}
-\usepackage{makeidx,mytabbing,fancyheadings}
+\usepackage{makeidx,mytabbing,fancyheadings,amsmath}
 \usepackage[dvipdfmx]{graphicx,color,epsfig}
 \let\epsfile=\epsfig
 \usepackage[dvipdfmx,bookmarks=true,bookmarksnumbered=true,bookmarkstype=toc]{hyperref}

--- a/doc/latex/matrix.tex
+++ b/doc/latex/matrix.tex
@@ -552,8 +552,8 @@ The result is equivalent to
 \subsection{Relationship between transformation matrix and coordinates class}
 
 \noindent
-Relationship between transformation matrix and coordinates class are described,
-when a transformation matrix T is represented a $4\times4$(homogeneous) matrix as below.
+Relationship between transformation matrix and coordinates class is described,
+where a transformation matrix T represents a $4\times4$(homogeneous) matrix as below.
 \[
 T = \begin{pmatrix}
 \mathbf{R}_T & \mathbf{p}_T \\
@@ -561,7 +561,7 @@ T = \begin{pmatrix}
 \end{pmatrix}
 \]
 
-$\mathbf{R}_T$ is $3\times3$ matrix, and $\mathbf{p}_T$ is $3\times1$ matrix
+$\mathbf{R}_T$ is a $3\times3$ matrix, and $\mathbf{p}_T$ is a $3\times1$ matrix
 (a float-vector which has 3 elements in euslisp).
 Coordinates class has
 slot variables rot and pos. They are $\mathbf{R}_T$ and $\mathbf{p}_T$ respectively.
@@ -570,10 +570,10 @@ slot variables rot and pos. They are $\mathbf{R}_T$ and $\mathbf{p}_T$ respectiv
 \noindent {\underline {\bf {\sf Getter method for rotation matrix and position}}}
 
 \noindent
-$\mathbf{R}$ and $\mathbf{p}$ can be taken out by a method in coordinates class.
+$\mathbf{R}$ and $\mathbf{p}$ can be obtained using methods of the coordinates class.
 
 \noindent
-T is a instance of coordinate class.
+T is an instance of the coordinate class.
 
 \noindent
 (send T :rot)
@@ -586,7 +586,7 @@ $\Rightarrow$ $\mathbf{R}_T$
 $\Rightarrow$ $\mathbf{p}_T$
 
 \vspace{1ex}
-\noindent {\underline {\bf {\sf Converting method for vector}}}
+\noindent {\underline {\bf {\sf Methods for transforming vectors}}}
 
 \noindent
 $\mathbf{v}$ is 3-D position vector.
@@ -606,7 +606,7 @@ $\Rightarrow$ $\mathbf{v}^T \mathbf{R}_T$
 
 $\Rightarrow$ $\mathbf{R}_T\mathbf{v} + \mathbf{p}_T$
 
-It converts a vector represented in a local coordinate system T
+Converts a vector represented in a local coordinate system T
 to a vector represented in the world coordinate system.
 
 \noindent
@@ -614,7 +614,7 @@ to a vector represented in the world coordinate system.
 
 $\Rightarrow$ $\mathbf{R}_T^{-1}\left( \mathbf{v} - \mathbf{p}_T \right)$
 
-It converts a vector represented in the world coordinate system.
+Converts a vector represented in the world coordinate system.
 to a vector represented in a local coordinate system T.
 
 \vspace{1ex}
@@ -625,7 +625,7 @@ to a vector represented in a local coordinate system T.
 
 $\Rightarrow$ $T^{-1}$
 
-It returns inverse matrix.
+Returns inverse matrix.
 \[
 T^{-1} = \begin{pmatrix}
  \mathbf{R}_T^{-1} & -\mathbf{R}_T^{-1}\mathbf{p}_T \\
@@ -647,13 +647,13 @@ when wrt == W (coordinates class), $W^{-1}AT^{-1}W$ is returned.
 \noindent {\underline {\bf {\sf Methods modifying itself}}}
 
 \noindent
-A is a instance of coordinates.
+A is an instance of the coordinates class.
 
 \noindent
 
 $\Leftrightarrow$ represents that
-slot variables (pos or rot) refer a given instance (matrix or float vector).
-Please note that when one is changed, it reflects to the other.
+slot variables (pos or rot) refer to a given instance (matrix or float vector).
+Please note that when one is changed, the other also reflects the change.
 
 
 \noindent

--- a/doc/latex/matrix.tex
+++ b/doc/latex/matrix.tex
@@ -548,4 +548,172 @@ The result is equivalent to
 {\tt (send {\em coords} :trans\-form-\-vec\-tor {\em vec})}.}
 \end{refdesc}
 
+\newpage
+\subsection{Relationship between transformation matrix and coordinates class}
+
+\noindent
+Relationship between transformation matrix and coordinates class are described,
+when a transformation matrix T is represented a $4\times4$(homogeneous) matrix as below.
+\[
+T = \begin{pmatrix}
+\mathbf{R}_T & \mathbf{p}_T \\
+\mathbf{0} & 1
+\end{pmatrix}
+\]
+
+$\mathbf{R}_T$ is $3\times3$ matrix, and $\mathbf{p}_T$ is $3\times1$ matrix
+(a float-vector which has 3 elements in euslisp).
+Coordinates class has
+slot variables rot and pos. They are $\mathbf{R}_T$ and $\mathbf{p}_T$ respectively.
+
+\vspace{1ex}
+\noindent {\underline {\bf {\sf Getter method for rotation matrix and position}}}
+
+\noindent
+$\mathbf{R}$ and $\mathbf{p}$ can be taken out by a method in coordinates class.
+
+\noindent
+T is a instance of coordinate class.
+
+\noindent
+(send T :rot)
+
+$\Rightarrow$ $\mathbf{R}_T$
+
+\noindent
+(send T :pos)
+
+$\Rightarrow$ $\mathbf{p}_T$
+
+\vspace{1ex}
+\noindent {\underline {\bf {\sf Converting method for vector}}}
+
+\noindent
+$\mathbf{v}$ is 3-D position vector.
+
+\noindent
+(send T :rotate-vector $\mathbf{v}$)
+
+$\Rightarrow$  $\mathbf{R}_T \mathbf{v}$
+
+\noindent
+(send T :inverse-rotate-vector $\mathbf{v}$)
+
+$\Rightarrow$ $\mathbf{v}^T \mathbf{R}_T$
+
+\noindent
+(send T :transform-vector $\mathbf{v}$)
+
+$\Rightarrow$ $\mathbf{R}_T\mathbf{v} + \mathbf{p}_T$
+
+It converts a vector represented in a local coordinate system T
+to a vector represented in the world coordinate system.
+
+\noindent
+(send T :inverse-transform-vector $\mathbf{v}$)
+
+$\Rightarrow$ $\mathbf{R}_T^{-1}\left( \mathbf{v} - \mathbf{p}_T \right)$
+
+It converts a vector represented in the world coordinate system.
+to a vector represented in a local coordinate system T.
+
+\vspace{1ex}
+\noindent {\underline {\bf {\sf Methods returing coordinates without modifying itself}}}
+
+\noindent
+(send T :inverse-transformation)
+
+$\Rightarrow$ $T^{-1}$
+
+It returns inverse matrix.
+\[
+T^{-1} = \begin{pmatrix}
+ \mathbf{R}_T^{-1} & -\mathbf{R}_T^{-1}\mathbf{p}_T \\
+ \mathbf{0} & 1
+\end{pmatrix}
+\]
+
+\noindent
+(send T :transformation A (\&optional (wrt :local)))
+
+when wrt == :local, $T^{-1}A$ is returned.
+
+when wrt == :world, $AT^{-1}$ is returned.
+
+when wrt == W (coordinates class), $W^{-1}AT^{-1}W$ is returned.
+
+
+\vspace{1ex}
+\noindent {\underline {\bf {\sf Methods modifying itself}}}
+
+\noindent
+A is a instance of coordinates.
+
+\noindent
+
+$\Leftrightarrow$ represents that
+slot variables (pos or rot) refer a given instance (matrix or float vector).
+Please note that when one is changed, it reflects to the other.
+
+
+\noindent
+$\leftarrow$ represents substitution.
+
+\noindent
+(send T :newcoords A)
+
+$\mathbf{R}_T \Leftrightarrow \mathbf{R}_A$
+
+$\mathbf{p}_T \Leftrightarrow \mathbf{p}_A$
+
+\noindent
+(send T :newcoords $\mathbf{R}$ $\mathbf{p}$)
+
+$\mathbf{R}_T \Leftrightarrow \mathbf{R}$
+
+$\mathbf{p}_T \Leftrightarrow \mathbf{p}$
+
+\noindent
+(send T :move-to A (\&optional (wrt :local)))
+
+when wrt == :local,$T \leftarrow TA$
+
+when wrt == :world,$T \Leftrightarrow A$
+
+when wrt == W (coordinates class), $T \leftarrow WA$
+
+\noindent
+(send T :translate $\mathbf{v}$ (\&optional (wrt :local)))
+
+when wrt == :local,
+$\mathbf{p}_{T} \leftarrow \mathbf{p}_{T} + \mathbf{R}_{T}\mathbf{v}$
+
+when wrt == :world,
+$\mathbf{p}_{T} \leftarrow \mathbf{p}_{T} + \mathbf{v}$
+
+when wrt == W (coordinates class),
+$\mathbf{p}_{T} \leftarrow \mathbf{p}_{T} + \mathbf{R}_{W}\mathbf{v}$
+
+\noindent
+(send T :locate $\mathbf{v}$ (\&optional (wrt :local)))
+
+when wrt == :local,
+$\mathbf{p}_{T} \leftarrow \mathbf{p}_{T} + \mathbf{R}_{T} \mathbf{v}$
+
+when wrt == :world,
+$\mathbf{p}_{T} \leftarrow \mathbf{v}$
+
+when wrt == W (coordinates class),
+$\mathbf{p}_{T} \leftarrow \mathbf{p}_{W} + \mathbf{R}_{W}\mathbf{v}$
+
+\noindent
+(send T :transform A (\&optional (wrt :local)))
+
+when wrt == :local, $T \leftarrow TA$
+
+when wrt == :world, $T \leftarrow AT$
+
+when wrt == W (coordinates class), $T \leftarrow$ $\left( WAW \right)^{-1} T$
+
+\newpage
 


### PR DESCRIPTION
coordinateクラスの変換行列を使った説明をマニュアルに追加しました。

@wesleypchan
Please review English version.

moved from: https://github.com/euslisp/jskeus/pull/140