### PR TITLE
fix pgsql.l for cygwin

### DIFF
--- a/lib/llib/pgsql.l
+++ b/lib/llib/pgsql.l
@@ -99,7 +99,9 @@
                ((probe-file "/usr/lib/i386-linux-gnu/libpq.so") (load "/usr/lib/i386-linux-gnu/libpq.so"))
                (t nil)))
 #+:cygwin
-(setq *libpq* (load "/usr/bin/cygpq.dll"))
+(setq *libpq* (cond
+               ((probe-file "/usr/bin/cygpq.dll") (load "/usr/bin/cygpq.dll"))
+               (t nil)))
 
 (when *libpq*
 (defforeign setdbLogin *libpq* "PQsetdbLogin"


### PR DESCRIPTION
@inabajsk

```
windows 10の上に昨日の時点でダウンロードできる
32bitのcygwin(2.6.0)をobsolateのチェックをはずしてインストールし
jskeusをbuildしてみると/usr/lib/cygpq.dllがないことで
eus/lib/llib/pgsql.l
でエラーがでるということで

(setq *libpq* (load "/usr/bin/cygpq.dll")
となっているのを

(setq *libpq* (cond
               ((probe-file "/usr/bin/cygpq.dll") (load "/usr/bin/cygpq.dll")
)
               (t nil)))

としておけばcygpq.dllがなくても、全体がbuildできてdemo.lも動くようになる。
llibは基本必要な時にロードして使えばいいのとpostgresqlを別途インストール
すればいいのかと思う。
```