### PR TITLE
[lisp/l/stream.l] fix: with-output-to-string returns nil -> string

### DIFF
--- a/lisp/l/stream.l
+++ b/lisp/l/stream.l
@@ -214,7 +214,8 @@
 
 (defmacro with-output-to-string (vstring &rest forms)
   `(let ((,(car vstring) (make-string-output-stream . ,(cdr vstring))))
-	. ,forms))
+     ,@forms
+     (get-output-stream-string ,(car vstring))))
 
 (defun get-output-stream-string (s)
    (subseq (stream-buffer s) 0 (stream-count s)))


### PR DESCRIPTION
`with-output-to-string` has now inconsistency between euslisp and common lisp.

refer: http://clhs.lisp.se/Body/m_w_out_.htm

**BEFORE**

``` lisp
$ irteusgl
$ (with-output-to-string (s) (format s "hoge"))
nil
```

``` lisp
$ sbcl
* (with-output-to-string (s) (format s "hoge"))

"hoge"
```

**AFTER**

``` lisp
$ irteusgl
$ (with-output-to-string (s) (format s "hoge"))
"hoge"
```
