### PR TITLE
[lisp/c/eus.h] guard when call classof with num

### DIFF
--- a/lisp/c/eus.h
+++ b/lisp/c/eus.h
@@ -722,7 +722,7 @@ extern int export_all;
 #define ccar(p) ((p)->c.cons.car)
 #define ccdr(p) ((p)->c.cons.cdr)
 #define cixof(p) ((p)->cix)
-#define classof(p) (classtab[(p)->cix].def)
+#define classof(p) (ispointer(p)?classtab[(p)->cix].def:(pointer)error(E_NOOBJECT))
 #define subcixof(p) (classtab[(p)->cix].subcix)
 #define speval(p) ((p)->c.sym.speval)
 #define spevalof(p,x) (ctx->specials->c.vec.v[x])


### PR DESCRIPTION
If called `classof` with number (== `!ispointer(v)`), it occurs segmentation fault.
After add guard, this will not segfault but just error:

``` lisp
eustf roseus_c_util /home/furushchev/ros/indigo_parent/devel/share/euslisp/jskeus/eus/Linux64/bin/irteusgl: ERROR th=0 object expected ;p=pointer?(0x4b7dd50)
#79158608# in (ros::spin)E: (exit)
```
