### PR TITLE
[lisp/c/specials.c] apply: delegate refer func pointer to ufuncall

### DIFF
--- a/lisp/c/specials.c
+++ b/lisp/c/specials.c
@@ -94,8 +94,7 @@ register pointer argv[];
   printf( "\n" );
 #endif
   if (issymbol(fun)) {
-    fun=fun->c.sym.spefunc;
-    if (fun==UNBOUND) error(E_UNDEF,argv[0]);}
+    if (fun->c.sym.spefunc==UNBOUND) error(E_UNDEF,argv[0]);}
   while (i<n-1) ckpush(argv[i++]);
   a=argv[i];
   while (islist(a)) {


### PR DESCRIPTION
in `APPLY` function, function pointer of symbol pointer is referred (line 97), and the pointer is passed to `ufuncall` which also refers function pointer.
In this pull request, `APPLY` function does NOT refer function pointer and delegates it to `ufuncall`.

This should resolve #210 