### PR TITLE
[WIP][.travis.sh] add temporal fix for rvm bug on latest travis OSX image

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -35,7 +35,7 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
 
 fi
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-
+    rvm get head || true # hotfix until rvm stable release (refer: https://github.com/travis-ci/travis-ci/issues/6307)
     travis_time_start setup.install
     brew tap homebrew/x11
     brew install jpeg libpng mesalib-glw wget;


### PR DESCRIPTION
OSX build fails every time since OS X Version on travis is updated.
(e.g. https://travis-ci.org/euslisp/EusLisp/jobs/173876765 )
This error occurs because current `rvm` stable that overwrites many builtin bash functions does not support new version of OSX bash.
https://github.com/travis-ci/travis-ci/issues/6307
