### PR TITLE
[lisp/c/lists.c] error if 2nd argument of butlast is negative number

### DIFF
--- a/lisp/c/lists.c
+++ b/lisp/c/lists.c
@@ -381,6 +381,7 @@ pointer argv[];
   if (!iscons(a)) {
     if (a==NIL) return(NIL);
     else error(E_NOLIST); }
+  if (n<0) error(E_USER,(pointer)"The second argument must be non-negative number");
   while (iscons(a)) { ckpush(ccar(a)); a=ccdr(a); count++;}
   n=min(count,n);
   ctx->vsp -= n;
@@ -398,6 +399,7 @@ pointer argv[];
   if (!iscons(a)) {
     if (a==NIL) return(NIL);
     else error(E_NOLIST); }
+  if (n<0) error(E_USER,(pointer)"The second argument must be non-negative number");
   while (iscons(a)) { ckpush(a); a=ccdr(a); count++;}
   n=min(count,n);
   b= *(ctx->vsp - n - 1);


### PR DESCRIPTION
This fixes #221 

```lisp
1.eus$ setq l (list 0 1 2 3 4)
(0 1 2 3 4)
2.eus$ butlast l -1
eus 0 error:  The second argument must be non-negative number in (butlast l -1)
```