### PR TITLE
[lisp/c/lists.c] error if butlast arguments of append are not list

### DIFF
--- a/lisp/c/lists.c
+++ b/lisp/c/lists.c
@@ -204,10 +204,10 @@ register pointer argv[];
   r=argv[--n];
   while (n>0) {
     a=argv[--n];
-    if (islist(a)) {
-      i=0;
-      while (islist(a)) { ckpush(ccar(a)); a=ccdr(a); i++;}
-      while (i-->0) r=cons(ctx,vpop(),r);}}
+    if (!islist(a) && a != NIL) error(E_NOLIST);
+    i=0;
+    while (islist(a)) { ckpush(ccar(a)); a=ccdr(a); i++;}
+    while (i-->0) r=cons(ctx,vpop(),r);}
   return(r);}
 
 pointer NCONC(ctx,n,argv)


### PR DESCRIPTION
This pull request fixes #208 .

```lisp
1.eus$ setq a (list 1 2 3)
(1 2 3)
2.eus$ setq b (list 4 5 6)
(4 5 6)
3.eus$ append a b
(1 2 3 4 5 6)
4.eus$ append a b 1
(1 2 3 4 5 6 . 1)
5.eus$ append 1 a
Call Stack (max depth: 20):
  0: at (append 1 a)
  1: at #<compiled-code #X59c1de0>
eus 0 error: list expected in (append 1 a)
```