### PR TITLE
Add foreign call test for arm64

### DIFF
--- a/contrib/eus64-check/Makefile
+++ b/contrib/eus64-check/Makefile
@@ -1,14 +1,31 @@
 
 all : test_foreign.so
 
+MARCH=$(shell uname -m)
+
 test_foreign.so : test_foreign.c
 ifeq ($(ARCHDIR), Linux64)
-	gcc -m64 -O2 -g -falign-functions=8 -Dx86_64 -DLinux -fPIC -c $<
-	gcc -m64 -shared -fPIC -falign-functions=8 -o $@ test_foreign.o
+##
+	gcc -O2 -g -falign-functions=8 -Dx86_64 -DLinux -fPIC -c $<
+	gcc -shared -fPIC -falign-functions=8 -o $@ test_foreign.o
 else
+ifeq ($(ARCHDIR), LinuxARM)
+ifeq ($(MARCH), aarch64)
+## arm 64bit
+	gcc -O2 -g -Wimplicit -falign-functions=8 -Daarch64 -Darmv8 -DARM -DLinux -fPIC -c $<
+	gcc -shared -fPIC -falign-functions=8 -o $@ test_foreign.o
+else
+## arm 32bit
+	gcc -O2 -g -falign-functions=4 -DARM -DLinux -fpic -c $<
+	gcc -shared -fpic -falign-functions=4 -o $@ test_foreign.o
+endif
+else
+## Linux32 bit
 	gcc -m32 -O2 -g -falign-functions=4 -Di386 -Di486 -DLinux -fpic -c $<
 	gcc -m32 -shared -fpic -falign-functions=4 -o $@ test_foreign.o
+endif
 endif
 
 clean :
 	\rm -f *.o *.so
+

--- a/contrib/eus64-check/eus64-test.l
+++ b/contrib/eus64-check/eus64-test.l
@@ -27,8 +27,27 @@
                                                           :integer :integer) :float)
   (defforeign call-ifunc *testmod* "call_ifunc" () :integer)
   (defforeign call-ffunc *testmod* "call_ffunc" () :float)
+
+  (defforeign get-size-pointer *testmod* "get_size_of_pointer" () :integer)
+  (defforeign get-size-float32 *testmod* "get_size_of_float32" () :integer)
+  (defforeign get-size-double  *testmod* "get_size_of_double" ()  :integer)
+  (defforeign get-size-long    *testmod* "get_size_of_long" () :integer)
+  (defforeign get-size-int     *testmod* "get_size_of_int" () :integer)
   )
 
+(format t "~%;;;; pointer size check ;;;;~%")
+
+(format t "pointer size ~D ~D~%"
+	lisp::sizeof-* (get-size-pointer))
+(format t "double size ~D ~D~%"
+	lisp::sizeof-double (get-size-double))
+(format t "long integer size ~D ~D~%"
+	(cadr (assoc :long lisp::sizeof-types))
+	(get-size-long))
+(format t "integer size ~D ~D~%"
+	lisp::sizeof-int (get-size-int))
+(format t "float size ~D ~D~%"
+	lisp::sizeof-float (get-size-float32))
 
 (format t "~%multiple arguments passing~%")
 (format t "expected result~%")

--- a/contrib/eus64-check/eus64-test.l
+++ b/contrib/eus64-check/eus64-test.l
@@ -31,14 +31,16 @@
 
 
 (format t "~%multiple arguments passing~%")
-(format t "expected result~%") 
+(format t "expected result~%")
 (format t "100 101 102
 103 104 105
 1000.000000 1010.000000 1020.000000 1030.000000
 1040.000000 1050.000000 1060.000000 1070.000000
 2080.000000 2090.000000
-206 207~%")
-(format t "exec in eus64~%")
+206 207
+test-testd = 1.23456
+~%")
+(format t "exec in eus~%")
 (format t "test-testd = ~A~%"
         (test-testd 100 101 102
             103 104 105
@@ -47,30 +49,30 @@
             2080.0 2090.0
             206 207))
 
-(format t "~%float-test~%")
+(format t "~%~%float-test~%")
 (format t "expected result~%")
 (format t "0: 1.000000e-01 ..~%")
 (format t "0: 2.000000e-01 ..~%")
 (format t "0: 3.000000e-01 ..~%")
 (format t "0: 4.000000e-01 ..~%")
-(format t "exec in eus64~%")
+(format t "~%float-test(success, exec in eus)~%")
 (float-test 0 0.1 0.2 0.3 0.4)
-(format t "~%float2-test~%")
+(format t "~%float2-test(fail, exec in eus)~%")
 (float2-test 0 0.1 0.2 0.3 0.4)
-(format t "~%float3-test~%")
+(format t "~%float3-test(depend on architecture, exec in eus)~%")
 (float3-test 0 0.1 0.2 0.3 0.4)
 
-(format t "~%double-test~%")
+(format t "~%~%double-test~%")
 (format t "expected result~%")
 (format t "1: 1.000000e-01 ..~%")
 (format t "1: 2.000000e-01 ..~%")
 (format t "1: 3.000000e-01 ..~%")
 (format t "1: 4.000000e-01 ..~%")
-(format t "exec in eus64~%")
+(format t "~%double-test(success, exec in eus)~%")
 (double-test 1 0.1 0.2 0.3 0.4)
-(format t "~%double2-test~%")
+(format t "~%double2-test(fail, exec in eus)~%")
 (double2-test 1 0.1 0.2 0.3 0.4)
-(format t "~%double3-test~%")
+(format t "~%double3-test(depend on architecture, exec in eus)~%")
 (double3-test 1 0.1 0.2 0.3 0.4)
 
 (setq iv (integer-vector 0 100 10000 1000000 100000000 10000000000))
@@ -88,7 +90,7 @@
 3: 1000000 F4240
 4: 100000000 5F5E100
 5: 10000000000 2540BE400~%")
-(format t "exec in eus64~%")
+(format t "~%lv-test(exec in eus)~%")
 (lv-test (length iv) iv)
 
 (setq fv (float-vector 0.1 0.2 0.3 0.5 0.7))
@@ -105,28 +107,30 @@
 2: 3.000000e-01 3FD3333333333330
 3: 5.000000e-01 3FE0000000000000
 4: 7.000000e-01 3FE6666666666664~%")
-(format t "exec in eus64~%")
+(format t "~%dv-test(exec in eus)~%")
 (dv-test (length fv) fv)
+
 
 (setq str "input : test64 string")
 (format t "~%str-test~%")
-(format t "expected result~%")
-(format t "print : ~S~%" str)
-(format t "exec in eus64~%")
+;;(format t "expected result~%")
+(format t "input string : ~S~%" str)
+(format t "~%str-test(exec in eus)~%")
 (str-test (length str) str)
 
 
 (format t "~%return double test~%")
 (format t "expected result~%")
-(format t "ret-double ~8,8e~%" (+ 0.55555 133.0))
-(format t "exec in eus64~%")
-(format t "ret-double ~8,8e~%" (ret-double 0.55555 133.0))
+(format t "  ret-double ~8,8e~%" (+ 0.55555 133.0))
+(format t "~%ret-double(exec in eus)~%")
+(format t "  ret-double ~8,8e~%" (ret-double 0.55555 133.0))
+
 
 (format t "~%return long test~%")
 (format t "expected result~%")
-(format t "ret-long ~D~%" (+ 123 645000))
-(format t "exec in eus64~%")
-(format t "ret-long ~D~%" (ret-long 123 645000))
+(format t "  ret-long ~D~%" (+ 123 645000))
+(format t "~%ret-long(exec in eus)~%")
+(format t "  ret-long ~D~%" (ret-long 123 645000))
 
 ;; ret-int
 ;; ret-short
@@ -138,9 +142,10 @@
   1234)
 ;;
 (format t "~%callback function test(integer)~%")
-(format t "callback function is set~%")
+(format t "  callback function is set~%")
 (set-ifunc (pod-address 'LISP-IFUNC))
-(format t "call-ifunc = ~A~%" (call-ifunc))
+(format t "  expected result: LISP-INTFUNC is called, return 1234~%")
+(format t "  call-ifunc = ~A~%" (call-ifunc))
 
 (defun-c-callable LISP-FFUNC ((i0 :integer) (i1 :integer) (i2 :integer)
                               (i3 :integer) (i4 :integer) (i5 :integer)
@@ -158,6 +163,14 @@
   (format t "return ~A~%" 0.12345)
   0.12345)
 (format t "~%callback function test(float)~%")
-(format t "callback function is set~%")
+(format t "  callback function is set~%")
 (set-ffunc (pod-address 'LISP-FFUNC))
+(format t "  expected result: LISP-FFUNC is called
+  100 101 102
+  103 104 105
+  1000.0 1010.0 1020.0 1030.0
+  1040.0 1050.0 1060.0 1070.0
+  2080.0 2090.0
+  206 207
+  return 0.12345~%")
 (format t "call-ffunc = ~A~%" (call-ffunc))

--- a/contrib/eus64-check/test_foreign.c
+++ b/contrib/eus64-check/test_foreign.c
@@ -194,3 +194,23 @@ double call_ffunc() {
             2080.0, 2090.0,
             206, 207);
 }
+
+long get_size_of_pointer() {
+  return (sizeof(void *));
+}
+
+long get_size_of_float32() {
+  return (sizeof(float));
+}
+
+long get_size_of_double() {
+  return (sizeof(double));
+}
+
+long get_size_of_long() {
+  return (sizeof(long));
+}
+
+long get_size_of_int() {
+  return (sizeof(int));
+}

--- a/contrib/eus64-check/test_foreign.c
+++ b/contrib/eus64-check/test_foreign.c
@@ -166,6 +166,7 @@ static double (*gf) (long i0, long i1, long i2,
 long set_ifunc(long (*f) ())
 {
   g = f;
+  printf("set_ifunc, g = %lX\n", g);
 }
 
 long set_ffunc(double (*f) ())
@@ -176,15 +177,16 @@ long set_ffunc(double (*f) ())
                     double d4, double d5, double d6, double d7,
                     double d8, double d9,
                     long i6, long i7))f;
+  printf("set_ffunc, gf = %lX\n", gf);
 }
 
 long call_ifunc() {
-  printf("g = %lX\n", g);
+  printf("call_ifunc, g = %lX\n", g);
   return g();
 }
 
 double call_ffunc() {
-  printf("gf = %lX\n", gf);
+  printf("call_ffunc, gf = %lX\n", gf);
   return gf(100,101,102,
             103,104,105,
             1000.0, 1010.0, 1020.0, 1030.0,


### PR DESCRIPTION
64bit環境でのforeign callの確認プログラムをarm環境にも使えるように修正しました。
現状では、defforeignした関数でfloat(double)の引数が正しく渡せていないように見えます。
(irteusの起動には問題にならないとおもいますが、defun-c-callableも使えていません）

arm64での結果(jetson)
~~~
multiple arguments passing
expected result
100 101 102
103 104 105
1000.000000 1010.000000 1020.000000 1030.000000
1040.000000 1050.000000 1060.000000 1070.000000
2080.000000 2090.000000
206 207
test-testd = 1.23456

exec in eus
100 101 102
103 104 105
2090.000000 0.000000 7880250456356283908564604316541551861735020379040734176922828969701338131516486153525912386248205537672376726431473213772565472275935434274045813587968.000000 -0.000000
0.000000 0.000000 0.000000 -0.000000
0.000000 0.000000
0 1083129856
test-testd = 1.23456


float-test
expected result
0: 1.000000e-01 ..
0: 2.000000e-01 ..
0: 3.000000e-01 ..
0: 4.000000e-01 ..

float-test(success, exec in eus)
0: 4.00000006e-01 3ECCCCCD
0: 2.59566264e-06 362E3125
0: 4.46505236e+30 72616D73
0: 0.00000000e+00 0

float2-test(fail, exec in eus)
0: -1.58818684e-23 9999999A
0: 7.26234208e+14 58252065
0: 5.37736191e+22 6536312E
0: 0.00000000e+00 0

float3-test(depend on architecture, exec in eus)
0: 4.00000006e-01 3ECCCCCD
0: 7.26234208e+14 58252065
0: 5.37736191e+22 6536312E
0: 0.00000000e+00 0


double-test
expected result
1: 1.000000e-01 ..
1: 2.000000e-01 ..
1: 3.000000e-01 ..
1: 4.000000e-01 ..

double-test(success, exec in eus)
1: 4.0000000000000002e-01 3FD999999999999A
1: 2.1950596086271573e-313 A58252065
1: 8.8717637733433208e+117 586C25206536312E
1:             -nan FFFFFF0000000000

double2-test(fail, exec in eus)
1: 5.2055209256998149e-315 3ECCCCCD
1: 2.1950596086271573e-313 A58252065
1: 8.8717637733433208e+117 586C25206536312E
1:             -nan FFFFFF0000000000

double3-test(depend on architecture, exec in eus)
1: 5.2055209256998149e-315 3ECCCCCD
1: 2.1950596086271573e-313 A58252065
1: 8.8717637733433208e+117 586C25206536312E
1:             -nan FFFFFF0000000000

lv-test
size = 6
0: 0 0
1: 100 64
2: 10000 2710
3: 1000000 F4240
4: 100000000 5F5E100
5: 10000000000 2540BE400

lv-test(exec in eus)
size = 6
0: 0 0
1: 100 64
2: 10000 2710
3: 1000000 F4240
4: 100000000 5F5E100
5: 10000000000 2540BE400

dv-test
size = 5
0: 1.000000e-01 3FB9999999999998
1: 2.000000e-01 3FC9999999999998
2: 3.000000e-01 3FD3333333333330
3: 5.000000e-01 3FE0000000000000
4: 7.000000e-01 3FE6666666666664

dv-test(exec in eus)
size = 5
0: 1.000000e-01 3FB9999999999998
1: 2.000000e-01 3FC9999999999998
2: 3.000000e-01 3FD3333333333330
3: 5.000000e-01 3FE0000000000000
4: 7.000000e-01 3FE6666666666664

str-test
input string : "input : test64 string"

str-test(exec in eus)
size = 21
0: i 69
1: n 6E
2: p 70
3: u 75
4: t 74
5:   20
6: : 3A
7:   20
8: t 74
9: e 65
10: s 73
11: t 74
12: 6 36
13: 4 34
14:   20
15: s 73
16: t 74
17: r 72
18: i 69
19: n 6E
20: g 67

return double test
expected result
  ret-double 1.33555550e+02

ret-double(exec in eus)
// return 2.173487e-312, 666D332A25
  ret-double 2.17348733e-312

return long test
expected result
  ret-long 645123

ret-long(exec in eus)
// return 645123, 9D803
  ret-long 645123
Call Stack (max depth: 20):
  0: at (send (let ((symbol foreign-pod)) (intern '"LISP-IFUNC" *package*)) :init 'nil ':integer #'(lambda nil (format t "LISP-INTFUNC is called, return ~D~%" 1234) 1234))
  1: at (progn (unintern '#:lisp-ifunc *package*) (send (let ((symbol foreign-pod)) (intern '"LISP-IFUNC" *package*)) :init 'nil ':integer #'(lambda nil (format t "LISP-INTFUNC is called, return ~D~%" 1234) 1234)))
  2: at (defun-c-callable #:lisp-ifunc nil :integer (format t "LISP-INTFUNC is called, return ~D~%" 1234) 1234)
eusg: ERROR th=0  0x473f398 in (send (let ((symbol foreign-pod)) (intern '"LISP-IFUNC" *package*)) :init 'nil ':integer #'(lambda nil (format t "LISP-INTFUNC is called, return ~D~%" 1234) 1234))E: 
~~~

Linux64での結果
~~~
multiple arguments passing
expected result
100 101 102
103 104 105
1000.000000 1010.000000 1020.000000 1030.000000
1040.000000 1050.000000 1060.000000 1070.000000
2080.000000 2090.000000
206 207
test-testd = 1.23456

exec in eus
100 101 102
103 104 105
1000.000000 1010.000000 1020.000000 1030.000000
1040.000000 1050.000000 1060.000000 1070.000000
2080.000000 2090.000000
206 207
test-testd = 1.23456


float-test
expected result
0: 1.000000e-01 ..
0: 2.000000e-01 ..
0: 3.000000e-01 ..
0: 4.000000e-01 ..

float-test(success, exec in eus)
0: 1.00000001e-01 3DCCCCCD
0: 2.00000003e-01 3E4CCCCD
0: 3.00000012e-01 3E99999A
0: 4.00000006e-01 3ECCCCCD

float2-test(fail, exec in eus)
0: -1.58818652e-23 99999998
0: -1.58818652e-23 99999998
0: 4.17232400e-08 33333330
0: -1.58818652e-23 99999998

float3-test(depend on architecture, exec in eus)
0: -1.58818652e-23 99999998
0: -1.58818652e-23 99999998
0: 4.17232400e-08 33333330
0: -1.58818652e-23 99999998


double-test
expected result
1: 1.000000e-01 ..
1: 2.000000e-01 ..
1: 3.000000e-01 ..
1: 4.000000e-01 ..

double-test(success, exec in eus)
1: 9.9999999999999978e-02 3FB9999999999998
1: 1.9999999999999996e-01 3FC9999999999998
1: 2.9999999999999982e-01 3FD3333333333330
1: 3.9999999999999991e-01 3FD9999999999998

double2-test(fail, exec in eus)
1: 5.1226304651152340e-315 3DCCCCCD
1: 5.1640756954075245e-315 3E4CCCCD
1: 5.1889428345710300e-315 3E99999A
1: 5.2055209256998149e-315 3ECCCCCD

double3-test(depend on architecture, exec in eus)
1: 9.9999999999999978e-02 3FB9999999999998
1: 1.9999999999999996e-01 3FC9999999999998
1: 2.9999999999999982e-01 3FD3333333333330
1: 3.9999999999999991e-01 3FD9999999999998

lv-test
size = 6
0: 0 0
1: 100 64
2: 10000 2710
3: 1000000 F4240
4: 100000000 5F5E100
5: 10000000000 2540BE400

lv-test(exec in eus)
size = 6
0: 0 0
1: 100 64
2: 10000 2710
3: 1000000 F4240
4: 100000000 5F5E100
5: 10000000000 2540BE400

dv-test
size = 5
0: 1.000000e-01 3FB9999999999998
1: 2.000000e-01 3FC9999999999998
2: 3.000000e-01 3FD3333333333330
3: 5.000000e-01 3FE0000000000000
4: 7.000000e-01 3FE6666666666664

dv-test(exec in eus)
size = 5
0: 1.000000e-01 3FB9999999999998
1: 2.000000e-01 3FC9999999999998
2: 3.000000e-01 3FD3333333333330
3: 5.000000e-01 3FE0000000000000
4: 7.000000e-01 3FE6666666666664

str-test
input string : "input : test64 string"

str-test(exec in eus)
size = 21
0: i 69
1: n 6E
2: p 70
3: u 75
4: t 74
5:   20
6: : 3A
7:   20
8: t 74
9: e 65
10: s 73
11: t 74
12: 6 36
13: 4 34
14:   20
15: s 73
16: t 74
17: r 72
18: i 69
19: n 6E
20: g 67

return double test
expected result
  ret-double 1.33555550e+02

ret-double(exec in eus)
// return 1.335556e+02, 4060B1C710CB295F
  ret-double 1.33555550e+02

return long test
expected result
  ret-long 645123

ret-long(exec in eus)
// return 645123, 9D803
  ret-long 645123

callback function test(integer)
  callback function is set
set_ifunc, g = 51469F0
  expected result: LISP-INTFUNC is called, return 1234
call_ifunc, g = 51469F0
LISP-INTFUNC is called, return 1234
  call-ifunc = 1234

callback function test(float)
  callback function is set
set_ffunc, gf = 5144560
  expected result: LISP-FFUNC is called
  100 101 102
  103 104 105
  1000.0 1010.0 1020.0 1030.0
  1040.0 1050.0 1060.0 1070.0
  2080.0 2090.0
  206 207
  return 0.12345
call_ffunc, gf = 5144560
LISP-FFUNC is called
100 101 102
103 104 105
1000.0 1010.0 1020.0 1030.0
1040.0 1050.0 1060.0 1070.0
2080.0 2090.0
206 207
return 0.12345
calleus float-result=0.123450
call-ffunc = 0.12345
~~~
