### PR TITLE
lispio.c:READLINE cb[i-1] && i>=1 is not correct, use i>=1 && cb[i-1]

### DIFF
--- a/lisp/c/lispio.c
+++ b/lisp/c/lispio.c
@@ -226,7 +226,7 @@ pointer argv[];
       if (eoferrorp==NIL) return(eofvalue);
       else error(E_EOF);}
     cb[i++]=ch;}
-  if (cb[i-1]=='\r' && (i>=1)) i=i-1;
+  if ((i>=1) && cb[i-1]=='\r') i=i-1;
   return(makestring((char *)cb,i));}
 
 pointer READCH(ctx,n,argv)


### PR DESCRIPTION
found by `-fsanitize=address -fno-omit-frame-pointer` 
cc: https://github.com/fkanehiro/hrpsys-base/issues/1154

```
[euslisp:make] /home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/obj/readmacro.o /home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/obj/common.o /home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/obj/pprint.o /home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/obj/stream.o /home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/obj/loader.o /home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/obj/eusdebug.o /home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/obj/process.o /home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/obj/packsym.o /home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/obj/object.o /home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/obj/coordinates.o /home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/obj/string.o /home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/obj/array.o /home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/obj/hashtab.o /home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/obj/eusforeign.o /home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/obj/mathtran.o /home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/obj/toplevel.o /home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/obj/tty.o /home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/obj/history.o /home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/obj/eushelp.o /home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/obj/par.o
[euslisp:make] =================================================================                                       
[euslisp:make] ==1309== ERROR: AddressSanitizer: stack-buffer-underflow on address 0x7ffde086677f at pc 0x45cad3 bp 0x7ffde0866730 sp 0x7ffde0866728
[euslisp:make] READ of size 1 at 0x7ffde086677f thread T0                                                              
[euslisp:make]     #0 0x45cad2 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x45cad2)              
[euslisp:make]     #1 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)              
[euslisp:make]     #2 0x452956 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x452956)              
[euslisp:make]     #3 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)              
[euslisp:make]     #4 0x41e1d3 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e1d3)              
[euslisp:make]     #5 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)              
[euslisp:make]     #6 0x41e1d3 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e1d3)              
[euslisp:make]     #7 0x454944 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x454944)              
[euslisp:make]     #8 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)              
[euslisp:make]     #9 0x41e1d3 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e1d3)              
[euslisp:make]     #10 0x41e896 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e896)             
[euslisp:make]     #11 0x41fb8a (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41fb8a)             
[euslisp:make]     #12 0x454263 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x454263)             
[euslisp:make]     #13 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #14 0x41e1d3 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e1d3)             
[euslisp:make]     #15 0x41e896 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e896)             
[euslisp:make]     #16 0x41fb8a (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41fb8a)             
[euslisp:make]     #17 0x421ddd (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x421ddd)             
[euslisp:make]     #18 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #19 0x4518c2 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x4518c2)             
[euslisp:make]     #20 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #21 0x41e1d3 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e1d3)             
[euslisp:make]     #22 0x41e896 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e896)             
[euslisp:make]     #23 0x41fb8a (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41fb8a)             
[euslisp:make]     #24 0x44f2e8 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x44f2e8)             
[euslisp:make]     #25 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #26 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #27 0x41e1d3 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e1d3)             
[euslisp:make]     #28 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #29 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #30 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #31 0x41e1d3 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e1d3)             
[euslisp:make]     #32 0x452fda (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x452fda)             
[euslisp:make]     #33 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #34 0x41e1d3 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e1d3)             
[euslisp:make]     #35 0x4541aa (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x4541aa)             
[euslisp:make]     #36 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #37 0x420402 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420402)             
[euslisp:make]     #38 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #39 0x41e1d3 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e1d3)             
[euslisp:make]     #40 0x4541aa (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x4541aa)             
[euslisp:make]     #41 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #42 0x41e1d3 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e1d3)             
[euslisp:make]     #43 0x41e896 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e896)             
[euslisp:make]     #44 0x426845 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x426845)             
[euslisp:make]     #45 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #46 0x421ddd (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x421ddd)             
[euslisp:make]     #47 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #48 0x4518c2 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x4518c2)             
[euslisp:make]     #49 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #50 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #51 0x420402 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420402)             
[euslisp:make]     #52 0x41e1d3 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e1d3)             
[euslisp:make]     #53 0x452fda (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x452fda)             
[euslisp:make]     #54 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #55 0x41e1d3 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e1d3)             
[euslisp:make]     #56 0x454cb4 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x454cb4)             
[euslisp:make]     #57 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #58 0x41e1d3 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e1d3)             
[euslisp:make]     #59 0x454944 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x454944)             
[euslisp:make]     #60 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #61 0x41e1d3 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e1d3)             
[euslisp:make]     #62 0x41e896 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e896)             
[euslisp:make]     #63 0x41fb8a (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41fb8a)             
[euslisp:make]     #64 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #65 0x41e1d3 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e1d3)             
[euslisp:make]     #66 0x4541aa (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x4541aa)             
[euslisp:make]     #67 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #68 0x41e1d3 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e1d3)             
[euslisp:make]     #69 0x41e896 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e896)             
[euslisp:make]     #70 0x41fb8a (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41fb8a)             
[euslisp:make]     #71 0x41e1d3 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e1d3)             
[euslisp:make]     #72 0x4541aa (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x4541aa)             
[euslisp:make]     #73 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #74 0x41e1d3 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e1d3)             
[euslisp:make]     #75 0x454cb4 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x454cb4)             
[euslisp:make]     #76 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #77 0x41e1d3 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e1d3)             
[euslisp:make]     #78 0x452fda (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x452fda)             
[euslisp:make]     #79 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #80 0x41e1d3 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e1d3)             
[euslisp:make]     #81 0x454cb4 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x454cb4)             
[euslisp:make]     #82 0x420388 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x420388)             
[euslisp:make]     #83 0x41e1d3 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e1d3)             
[euslisp:make]     #84 0x41e896 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41e896)             
[euslisp:make]     #85 0x41fb8a (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x41fb8a)             
[euslisp:make]     #86 0x4b0b17 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x4b0b17)             
[euslisp:make]     #87 0x4b4859 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x4b4859)             
[euslisp:make]     #88 0x40e887 (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x40e887)             
[euslisp:make]     #89 0x2ab66f800f44 (/lib/x86_64-linux-gnu/libc-2.19.so+0x21f44)                                     
[euslisp:make]     #90 0x40ea1b (/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/bin/eus0+0x40ea1b)             
[euslisp:make] Address 0x7ffde086677f is located at offset 31 in frame <READLINE> of T0's stack:                       
[euslisp:make]   This frame has 1 object(s):                                                                           
[euslisp:make]     [32, 8224) 'cb'                                                                                     
[euslisp:make] HINT: this may be a false positive if your program uses some custom stack unwind mechanism or swapcontext
[euslisp:make]       (longjmp and C++ exceptions *are* supported)                                                      
[euslisp:make] Shadow bytes around the buggy address:                                                                  
[euslisp:make]   0x10003c104c90: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00                                       
[euslisp:make]   0x10003c104ca0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00                                       
[euslisp:make]   0x10003c104cb0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00                                       
[euslisp:make]   0x10003c104cc0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00                                       
[euslisp:make]   0x10003c104cd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00                                       
[euslisp:make] =>0x10003c104ce0: 00 00 00 00 00 00 00 00 00 00 00 00 f1 f1 f1[f1]                                      
[euslisp:make]   0x10003c104cf0:00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00                                        
[euslisp:make]   0x10003c104d00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00                                       
[euslisp:make]   0x10003c104d10: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00                                       
[euslisp:make]   0x10003c104d20: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00                                       
[euslisp:make]   0x10003c104d30: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00                                       
[euslisp:make] Shadow byte legend (one shadow byte represents 8 application bytes):                                    
[euslisp:make]   Addressable:           00                                                                             
[euslisp:make]   Partially addressable: 01 02 03 04 05 06 07                                                           
[euslisp:make]   Heap left redzone:     fa                                                                             
[euslisp:make]   Heap righ redzone:     fb                                                                             
[euslisp:make]   Freed Heap region:     fd                                                                             
[euslisp:make]   Stack left redzone:    f1                                                                             
[euslisp:make]   Stack mid redzone:     f2                                                                             
[euslisp:make]   Stack right redzone:   f3                                                                             
[euslisp:make]   Stack partial redzone: f4                                                                             
[euslisp:make]   Stack after return:    f5                                                                             
[euslisp:make]   Stack use after scope: f8                                                                             
[euslisp:make]   Global redzone:        f9                                                                             
[euslisp:make]   Global init order:     f6                                                                             
[euslisp:make]   Poisoned by user:      f7                                                                             
[euslisp:make]   ASan internal:         fe                                                                             
[euslisp:make] ==1309== ABORTING                                                                                       
[euslisp:make] make[4]: *** [/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/Linux64/obj/compile_l.log] Error 1         
[euslisp:make] make[4]: Leaving directory `/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/lisp'                        
[euslisp:make] make[3]: *** [all] Error 2                                                                              
[euslisp:make] make[3]: Leaving directory `/home/k-okada/catkin_ws/ws_euslisp/src/euslisp/lisp'                        
[euslisp:make] make[2]: Leaving directory `/home/k-okada/catkin_ws/ws_euslisp/build/euslisp'                           
[euslisp:make] make[2]: *** [CMakeFiles/compile_euslisp] Error 2                                                       
[euslisp:make] make[1]: *** [CMakeFiles/compile_euslisp.dir/all] Error 2                                               
[euslisp:make] make[1]: Leaving directory `/home/k-okada/catkin_ws/ws_euslisp/build/euslisp'                           
[euslisp:make] make: *** [all] Error 2  
```

