### PR TITLE
show warning when undefined function found

### DIFF
--- a/lisp/comp/trans.l
+++ b/lisp/comp/trans.l
@@ -247,6 +247,9 @@
        (if (null entry) (setq entry (get sym 'builtin-function-entry)))
        (send self :clearpush)
        (send self :reset-vsp)
+       (unless (functionp sym)
+         (format *error-output* "; ~C[34;7m~S~C[0;34m is assumed to be undefined function~C[0m~%"
+                 #x1b sym #x1b #x1b))
        (if entry
 	   (format cfile "	w=(pointer)~A(ctx,~d,local+~d); /*~A*/~%"
 		     entry n (- pushcount n) sym)


### PR DESCRIPTION
with this PR we can find `unix:uleep` case (https://github.com/start-jsk/jsk_apc/pull/2241#pullrequestreview-48776645)
cc: https://github.com/start-jsk/jsk_apc/pull/2497
```
$ (progn (load "~/catkin_ws/ws_jsk_apc/src/euslisp/euslisp/lisp/comp/trans.l")(comp::compile-file "hoge.l"))
compiling file: hoge.l
; bb is assumed to be global
; bb is assumed to be global
; unix::uleep is assumed to be undefined function
gcc -g -c -Dx86_64 -DLinux -Wimplicit -falign-functions=8 -DGCC3  -DGCC  -DTHREADED -DPTHREAD -fpic  -I/opt/ros/indigo/share/euslisp/jskeus/eus/include -O2 hoge.c; ld -shared -build-id -o hoge.so hoge.o
```

```
$ cat hoge.l

(defun fuga nil
  (setq bb 10)
  (unix:usleep 1)
  )

(defun hoge nil
  (setq bb 10)
  (unix::uleep 1) ;;this fails in compie
  )
```