### PR TITLE
Fixes entity symbol for compiled library files whose name contains '-'

### DIFF
--- a/lisp/comp/comp.l
+++ b/lisp/comp/comp.l
@@ -220,21 +220,8 @@
    (concatenate string (string (gensym head)) suffix))
  (:gencname-tail 
   (&rest lnames)
-  (labels ((cchar-p (c) 
-                    (or (and (<= #\a c) (<= c #\z)) 
-                        (and (<= #\A c) (<= c #\Z)) 
-                        (and (<= #\0 c) (<= c #\9)) 
-                        (= c #\_)))
-           (replace-to-cchars 
-            (lnames)
-            (let ((lnamestr (reduce 
-                             #'(lambda (u v) (format nil "~a~a" u v)) 
-                             lnames :initial-value "")))
-              (coerce 
-               (mapcar 
-                #'(lambda (c) (if (cchar-p c) c #\_)) 
-                (coerce lnamestr cons)) string))))
-          (replace-to-cchars lnames)))
+  ;; NOTE: Deprecated. Use lisp::gencname-tail instead. (2017/10/19 furushchev)
+  (apply #'lisp::gencname-tail lnames))
  (:progn (bodies)
     (if bodies
       (while bodies
@@ -1104,7 +1091,7 @@
    (if (eq (car form) 'defun)
      (let* ((name (cadr form))
             (cname (send self :genlabel "F"
-                         (send self :gencname-tail name)
+                         (lisp::gencname-tail name)
                         )))
        (putprop name cname 'user-function-entry)
        (push name *defun-list*))))
@@ -1142,7 +1129,7 @@
 	       param (cons 'self (cons 'class (cadr method)))
 	       bodies (cddr method) )
          (setq entry (send self :genlabel "M"
-                           (send self :gencname-tail myclass selector)))
+                           (lisp::gencname-tail myclass selector)))
 	 (setq doc 
 	       (if (and (stringp (car bodies))  (cdr bodies))
 		   (pop bodies)
@@ -1225,7 +1212,7 @@
 		 (cc *do-cc*)	;nil skips c-compilation
 		 (pic *pic*)	;t forces position independent code 
 		 (verbose *verbose*)
-		 (entry (send self :gencname-tail (pathname-name file)))
+		 (entry (lisp::gencname-tail (pathname-name file)))
 		 (o))
    (if (and (integerp c-optimize)
 	    (> c-optimize 0)

--- a/lisp/l/loader.l
+++ b/lisp/l/loader.l
@@ -182,6 +182,25 @@
 (defvar *loaded-modules* nil)
 (defun load-module-file-name (lm) (pathname-name (load-module-object-file lm )))
 
+(defun gencname-tail (&rest lnames)
+  "Make symbol name C-language safe."
+  ;; moved from comp/comp.l (2017/10/19 furushchev)
+  (labels ((cchar-p (c) 
+             (or (and (<= #\a c) (<= c #\z)) 
+                 (and (<= #\A c) (<= c #\Z)) 
+                 (and (<= #\0 c) (<= c #\9)) 
+                 (= c #\_)))
+           (replace-to-cchars 
+               (lnames)
+             (let ((lnamestr (reduce 
+                              #'(lambda (u v) (format nil "~a~a" u v)) 
+                              lnames :initial-value "")))
+               (coerce 
+                (mapcar 
+                 #'(lambda (c) (if (cchar-p c) c #\_)) 
+                 (coerce lnamestr cons)) string))))
+    (replace-to-cchars lnames)))
+
 (defun load (fname  &key (quote-file  nil)
 			  (entry (concatenate string "___"
 						(pathname-name fname)))

--- a/lisp/l/loader.l
+++ b/lisp/l/loader.l
@@ -202,8 +202,9 @@
     (replace-to-cchars lnames)))
 
 (defun load (fname  &key (quote-file  nil)
-			  (entry (concatenate string "___"
-						(pathname-name fname)))
+			  (entry (gencname-tail
+			          (concatenate string "___"
+			                       (pathname-name fname))))
 			  (symbol-input)
 			  (symbol-output "")
 			  (ld-option "")


### PR DESCRIPTION
Fixes #250 

Fixes entity symbol for compiled library files.

To use the same function defintiion for escaping symbol name, `:gencname-tail` method of `compiler:comp` class is moved to a function named `lisp::gencname-tail`.
(Because `comp/comp.l` depends on `l/loader.l`)