### PR TITLE
:parent-orientation でのエラー表示

### DIFF
--- a/lisp/l/coordinates.l
+++ b/lisp/l/coordinates.l
@@ -222,7 +222,7 @@
 	 ((or (memq wrt '(:parent parent :world world nil))
 	      (eq wrt *world-coords*)) v)
 	 ((coordinates-p wrt)   (transform  (send wrt :worldrot) v))
-	 (t (send self :error ":parent-orientation wrt?" wrt))))
+	 (t (send self :error ":parent-orientation wrt? wrt must be either :world, :local or :parent" wrt))))
   (:translate (vec &optional (wrt :local))
      (send self :newcoords
 	   rot (v+ (send self :parent-orientation vec wrt) pos pos)))

--- a/lisp/l/coordinates.l
+++ b/lisp/l/coordinates.l
@@ -222,7 +222,7 @@
 	 ((or (memq wrt '(:parent parent :world world nil))
 	      (eq wrt *world-coords*)) v)
 	 ((coordinates-p wrt)   (transform  (send wrt :worldrot) v))
-	 (t (send self :error ":parent-orientation wrt? wrt must be either :world, :local or :parent" wrt))))
+	 (t (send self :error ":parent-orientation wrt? wrt must be :world, :local, :parent or coordinates instance" wrt))))
   (:translate (vec &optional (wrt :local))
      (send self :newcoords
 	   rot (v+ (send self :parent-orientation vec wrt) pos pos)))


### PR DESCRIPTION
`:parent-orientation`で、wrtが正しくセットされていない時に表示されるエラーに追記しました。