### PR TITLE
Return position in substringp

### DIFF
--- a/lisp/l/string.l
+++ b/lisp/l/string.l
@@ -128,7 +128,7 @@
        (j 0 (1+ j)))
       ((> j i) nil)
     (when (string-equal sub str :start2 j  :end2 (+ j l))
-          (return-from substringp t))))
+          (return-from substringp j))))
 
 (defmethod string
   (:get (pos type) (sys:peek self pos type) )


### PR DESCRIPTION
Makes `substringp` return matching position instead of `t`, in order to resemble Common Lisp's `search` function. http://clhs.lisp.se/Body/f_search.htm

```
eus$ (substringp "arm" "rarm-controller")
1
eus$ (substringp "end-coords" "rarm-end-coords")
5
```

This enables writing something like
```
eus$ (let ((str "rarm-end-coords"))
  (subseq str 0 (substringp "-end-coords" str)))
"rarm"
```
While preserving original functionality.

Please let me know if it should be better to define `search` separately.