### PR TITLE
[lisp/c/matrix.c] check norm is not nan in rotation-angle

### DIFF
--- a/lisp/c/matrix.c
+++ b/lisp/c/matrix.c
@@ -1103,14 +1103,14 @@ pointer argv[];
     printf("rotation-angle1: %f %f %f\n",kx,ky,kz);
   if ((fabs(kx) > fabs(ky)) && (fabs(kx) > fabs(kz))) {
     ky=(m[size]+m[1])/(2*kx*vers); kz=(m[2]+m[size+size])/(2*kx*vers);
-    norm=sqrt((ky*ky+kz*kz)/(1.0-kx*kx)); ky/=norm; kz/=norm;}
+    norm=sqrt((ky*ky+kz*kz)/(1.0-kx*kx)); if (!isnan(norm)) {ky/=norm; kz/=norm;}}
   else if ((fabs(ky) > fabs(kx)) && (fabs(ky) > fabs(kz))) {
     kx=(m[size]+m[1])/(2*ky*vers); kz=(m[size+2]+m[size+size+1])/(2*ky*vers);
-    norm=sqrt((kx*kx+kz*kz)/(1.0-ky*ky)); kx/=norm; kz/=norm;}
+    norm=sqrt((kx*kx+kz*kz)/(1.0-ky*ky)); if (!isnan(norm)) {kx/=norm; kz/=norm;}}
   else {
     kx=(m[2]+m[size+size])/(2*kz*vers);
     ky=(m[size+2]+m[size+size+1])/(2*kz*vers);
-    norm=sqrt((kx*kx+ky*ky)/(1.0-kz*kz)); kx/=norm; ky/=norm;}
+    norm=sqrt((kx*kx+ky*ky)/(1.0-kz*kz)); if (!isnan(norm)) {kx/=norm; ky/=norm;}}
   /**/
   norm=sqrt(kx*kx + ky*ky + kz*kz);
   if (debug) 


### PR DESCRIPTION
This supports the case of rotating around x,y,z axis.
In other situation, behavior should not change.

before PR
```lisp
6.irteusgl$ (rotation-angle (send (make-coords :axis #f(1 0 0) :angle 0.5) :rot))
(0.5 #f(-nan -nan -nan))
```
after PR
```lisp
6.irteusgl$ (rotation-angle (send (make-coords :axis #f(1 0 0) :angle 0.5) :rot))
(0.5 #f(1 0 0))
```

