### PR TITLE
[lisp/geo/geopack.l] get face :distance :method when point is on the same plane

### DIFF
--- a/lisp/geo/geopack.l
+++ b/lisp/geo/geopack.l
@@ -1164,11 +1164,15 @@ Normal must be given if the sign of the angle is needed."
  (:distance (point)
     (let (foot (sign (signum (send self :plane-distance point))))
        (setq foot (send self :foot point))
-       (* sign 
-	  (if (memq (send self :insidep foot) '(:inside :parallel))
-	      (distance foot point)
+       (if (= sign 0.0)	;; on the same plane
+	   (if (memq (send self :insidep foot) '(:inside :parallel))
+	       0.0
+	       (apply #'min (send-all (send self :all-edges) :distance point)))
+         (* sign
+            (if (memq (send self :insidep foot) '(:inside :parallel))
+                (distance foot point)
 	      (apply #'min (send-all (send self :all-edges)
-				     :distance point))))) )
+				     :distance point))))) ))
  (:area ()
     (- (send-super :area) (apply #'+ (send-all holes :area))))
 #|


### PR DESCRIPTION
In the :distance method of face class, 0 is returned in the case that point is on the same plane with face even if point is not contained in face. This is because the case that `sign` is 0 is not treated correctly.

The same treatment is already done in :distance method of polygon class, and I copied this.
https://github.com/euslisp/EusLisp/blob/master/lisp/geo/geopack.l#L907-L910