### PR TITLE
[lisp/geo/geopack.l] normalize norm vector in optional arugment of vector-angle function.

### DIFF
--- a/lisp/geo/geopack.l
+++ b/lisp/geo/geopack.l
@@ -98,7 +98,7 @@ left hand side of line a-b, and b lies at the right side of ac."
 "normal vector for the plane on which three points (a b c) lie."
    (normalize-vector (v* (v- b a) (v- c a))))
 
-(defun vector-angle (v1 v2 &optional (normal (v* v1 v2)))
+(defun vector-angle (v1 v2 &optional (normal (normalize-vector (v* v1 v2))))
 "Compute angle (radian) between two vectors, v1 and v2.
 Normal is vertical to both v1 and v2.
 v1, v2 and normal must be normalized in advance.

--- a/lisp/geo/geopack.l
+++ b/lisp/geo/geopack.l
@@ -98,11 +98,13 @@ left hand side of line a-b, and b lies at the right side of ac."
 "normal vector for the plane on which three points (a b c) lie."
    (normalize-vector (v* (v- b a) (v- c a))))
 
-(defun vector-angle (v1 v2 &optional (normal (normalize-vector (v* v1 v2))))
+(defun vector-angle (v1 v2 &optional (normal (normalize-vector (v* v1 v2))) (parallel-thre 1e-10))
 "Compute angle (radian) between two vectors, v1 and v2.
 Normal is vertical to both v1 and v2.
 v1, v2 and normal must be normalized in advance.
 Normal must be given if the sign of the angle is needed."
+    (if (< (norm2 (v* v1 v2)) parallel-thre)
+        (return-from vector-angle (if (> (v. v1 v2) 0) 0.0 pi)))
     (atan (v.* normal v1 v2) (v. v1 v2)) )
 
 (defun face-normal-vector (vertices)


### PR DESCRIPTION
As described in document https://github.com/euslisp/EusLisp/blob/master/lisp/geo/geopack.l#L104, normal argument should be unit length. Default value of optional argument is very bad because `(v* v1 v2)` does not become unit-length when v1 and v2 have some angle (> 0).
This PR makes https://github.com/euslisp/jskeus/pull/485 test pass.