### PR TITLE
compile-file: support filename without './'

### DIFF
--- a/lisp/comp/comp.l
+++ b/lisp/comp/comp.l
@@ -1223,6 +1223,8 @@
    (setq *optimize* optimize
 	 *safety* safety
 	 *verbose* verbose)
+   (unless (send (pathname file) :directory)
+     (setq file (namestring (merge-pathnames "./" file))))
    (when o
 	   (setq o (pathname o))
 	   (setq o (merge-pathnames o file))


### PR DESCRIPTION
current `compile-file` function requies `./` prefix when you load a file in current directory,

```
3.eus2$ (compile-file "test-plus.l")
Call Stack (max depth: 20):
  0: at (compiler:compile-file "test-plus.l")
  1: at (compiler:compile-file "test-plus.l")
  2: at #<compiled-code #X56cb828>
eus2 0 error: cannot find method :directory-string in (compiler:compile-file "test-plus.l")
```

which may cause confusion when you firs^Csee the error message

c.f. #265