### PR TITLE
fix for KEYWORKDPARAMETERLIMIT update

### DIFF
--- a/lisp/c/eval.c
+++ b/lisp/c/eval.c
@@ -319,7 +319,7 @@ struct bindframe *env,*bf;
       inits[nokeys]=initform;
       nokeys++;
       if (nokeys>=KEYWORDPARAMETERLIMIT) {
-	error(E_USER, "Too many keyword parameters >32"); 
+	error(E_USER, "Too many keyword parameters >%d",KEYWORDPARAMETERLIMIT);
 	}
       }	
   n=0;

--- a/lisp/comp/comp.l
+++ b/lisp/comp/comp.l
@@ -1004,7 +1004,7 @@
 	(nreverse key-vars)
 	(nreverse key-inits)
 	;(format t ";key-names length=~d ~s~%" (length key-names)  key-names)
-	(if (>= (length key-names) 128)
+	(if (>= (length key-names) 128) ;; KEYWORDPARAMETERLIMIT
 	    (send self :error "Too many keyword parameters>128 ~s" key-names))
         ) )
 ;; declaration

--- a/lisp/comp/comp.l
+++ b/lisp/comp/comp.l
@@ -1004,8 +1004,8 @@
 	(nreverse key-vars)
 	(nreverse key-inits)
 	;(format t ";key-names length=~d ~s~%" (length key-names)  key-names)
-	(if (>= (length key-names) 32)
-	    (send self :error "Too many keyword parameters>32 ~s" key-names))
+	(if (>= (length key-names) 128)
+	    (send self :error "Too many keyword parameters>128 ~s" key-names))
         ) )
 ;; declaration
      (while (and forms (consp (car forms)) (eq (caar forms) 'declare))


### PR DESCRIPTION
KEYWORDPARAMETERLIMIT was extended from 32 to 128 in the following commit:
fb61d77

and we forget to increase the magic number in comp.l


-  add comment where 128 comes from
- check if key-names is learger than 128, not 32. see fb61d77

Closes #263