### PR TITLE
skip brew install if already installed

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -36,7 +36,12 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
 fi
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     travis_time_start setup.install
-    brew install jpeg libpng mesalib-glw;
+    # skip if already installed
+    # https://discourse.brew.sh/t/skip-ignore-brew-install-if-package-is-already-installed/633/2
+    # brew install jpeg libpng mesalib-glw;
+    brew list jpeg &>/dev/null || brew install jpeg
+    brew list libpng &>/dev/null || brew install libpng
+    brew list mesalib-glw &>/dev/null || brew install mesalib-glw
     travis_time_end
 
 fi


### PR DESCRIPTION
osx build is not stable...., we had this error as of 2018/3/14

https://travis-ci.org/euslisp/EusLisp/jobs/353245673

```
zeromq@4.1
Warning: libpng 1.6.34 is already installed
Error: jpeg 9b is already installed
To upgrade to 9c, run `brew upgrade jpeg`
```

previous fix was feb 2018 ... https://github.com/euslisp/EusLisp/pull/259