### PR TITLE
if normalize-vector takes zero vector, return zero vector instead of nan vector

### DIFF
--- a/lisp/c/matrix.c
+++ b/lisp/c/matrix.c
@@ -308,6 +308,9 @@ register pointer argv[];
   for (i=0; i<s; i++) sum+= a[i]*a[i];
   sum=sqrt(sum);
   for (i=0; i<s; i++) r[i]=a[i]/sum;
+  int all_nan=1; /* if all element is nan, return 0 vector */
+  for (i=0; i<s; i++) if (!isnan(r[i])) all_nan=0; // false
+  if (all_nan) for (i=0; i<s; i++) r[i]=0;
   return(result);}
   
 pointer VDISTANCE(ctx,n,argv)


### PR DESCRIPTION
current EusLisp implemnetatoin returns `#f(nan nan nan)` for `#f(0 0 0)` input.
However if yo uuse jskeus, it returns `#f(0 0 0)` for `#f(0 0 0) input.

https://github.com/euslisp/jskeus/blob/master/irteus/irtmath.l#L610-L620

So this will not affect normal jskeus users, and will make https://github.com/euslisp/EusLisp/pull/264 much simpler

how do you think? @mmurooka, @YyoheiKakiuchi