### PR TITLE
fix default documentation of defun for C language

### DIFF
--- a/lisp/c/makes.c
+++ b/lisp/c/makes.c
@@ -622,6 +622,7 @@ char *doc;
 
   pkg=Spevalof(PACKAGE);
   sym=intern(ctx,name,strlen(name),pkg);
+  pdoc = NIL;
   if (doc != NULL) {
     pdoc = makestring(doc,strlen(doc));
     vpush(pdoc);


### PR DESCRIPTION
Fix for https://github.com/euslisp/EusLisp/pull/116
If there is no documentation string ( = NULL ), documentation should be NIL.