### PR TITLE
Revert "In sequence.c, start/end parameter check is corrected for arrays        since specifying start>end caused a segmentation fault."

### DIFF
--- a/lisp/c/sequence.c
+++ b/lisp/c/sequence.c
@@ -142,9 +142,7 @@ pointer argv[];
     a=a->c.ary.entity;}
   if (isvector(a)) {
     count=vecsize(a);
-    if (s>count) error(E_STARTEND);
-    if (n==3) {
-      if (e>count) error(E_STARTEND); }
+    if (n==3) e=min(e,count);
     else e=count;
     count=e-s;
     switch(elmtypeof(a)) {


### PR DESCRIPTION
Reverts euslisp/EusLisp#285

this causes https://github.com/jsk-ros-pkg/jsk_roseus/pull/568, I think we'd better to revert for now
```
EusLisp 9.23(9f1e900) for Linux64 created on p51s(Thu Jul 12 20:50:33 JST 2018)
1.eus2$ (subseq "0123456789" 0 5)
"01234"
2.eus2$ (subseq "0123456789" 0 10)
"0123456789"
3.eus2$ (subseq "0123456789" 0 15)
Call Stack (max depth: 20):
  0: at (subseq "0123456789" 0 15)
  1: at #<compiled-code #X62b0540>
eus2 0 error: illegal start/end index in (subseq "0123456789" 0 15)
4.E1-eus2$ reset
5.eus2$ (subseq (list 0 1 2 3 4 5 6 7 8 9) 0 5)
(0 1 2 3 4)
6.eus2$ (subseq (list 0 1 2 3 4 5 6 7 8 9) 0 10)
(0 1 2 3 4 5 6 7 8 9)
7.eus2$ (subseq (list 0 1 2 3 4 5 6 7 8 9) 0 15)
(0 1 2 3 4 5 6 7 8 9)
8.eus2$ (subseq #i(0 1 2 3 4 5 6 7 8 9) 0 5)
#i(0 1 2 3 4)
9.eus2$ (subseq #i(0 1 2 3 4 5 6 7 8 9) 0 10)
#i(0 1 2 3 4 5 6 7 8 9)
10.eus2$ (subseq #i(0 1 2 3 4 5 6 7 8 9) 0 15)
Call Stack (max depth: 20):
  0: at (subseq #i(0 1 2 3 4 5 6 7 8 9) 0 15)
  1: at #<compiled-code #X62b0540>
eus2 0 error: illegal start/end index in (subseq #i(0 1 2 3 4 5 6 7 8 9) 0 15)
11.E1-eus2$ reset
12.eus2$ (subseq #f(0 1 2 3 4 5 6 7 8 9) 0 5)
#f(0.0 1.0 2.0 3.0 4.0)
13.eus2$ (subseq #f(0 1 2 3 4 5 6 7 8 9) 0 10)
#f(0.0 1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0)
14.eus2$ (subseq #f(0 1 2 3 4 5 6 7 8 9) 0 15)
Call Stack (max depth: 20):
  0: at (subseq #f(0.0 1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0) 0 15)
  1: at #<compiled-code #X62b0540>
eus2 0 error: illegal start/end index in (subseq #f(0.0 1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0) 0 15)
15.E1-eus2$ reset
```
```
[1]> (subseq (list 0 1 2 3 4 5 6 7 8 9) 0 5)
(0 1 2 3 4)
[2]> (subseq (list 0 1 2 3 4 5 6 7 8 9) 0 10)
(0 1 2 3 4 5 6 7 8 9)
[3]> (subseq (list 0 1 2 3 4 5 6 7 8 9) 0 15)

*** - SYSTEM::LIST-ACCESS: NIL is not a pair
The following restarts are available:
USE-VALUE      :R1      Input a value to be used instead.
ABORT          :R2      Abort main loop
Break 1 [4]> (reset)

*** - EVAL: undefined function RESET
The following restarts are available:
USE-VALUE      :R1      Input a value to be used instead of (FDEFINITION 'RESET).
RETRY          :R2      Retry
STORE-VALUE    :R3      Input a new value for (FDEFINITION 'RESET).
ABORT          :R4      Abort debug loop
ABORT          :R5      Abort main loop
Break 2 [5]> :q
[6]> (subseq "0123456789" 0 15)

*** - AREF: index 10 for "0123456789" is out of range
The following restarts are available:
ABORT          :R1      Abort main loop
Break 1 [7]> :q
[8]> (subseq "0123456789" 0 5)
"01234"
[9]> (subseq "0123456789" 0 10)
"0123456789"
[10]> (subseq #i(0 1 2 3 4 5 6 7 8 9) 0 5)

*** - READ from #<INPUT CONCATENATED-STREAM #<INPUT STRING-INPUT-STREAM> #<IO TERMINAL-STREAM>>: After
      #\# is #\i an undefined dispatch macro character
The following restarts are available:
ABORT          :R1      Abort main loop
Break 1 [11]> 

```