### PR TITLE
In sequence.c, start/end parameter check is corrected for arrays

### DIFF
--- a/lisp/c/sequence.c
+++ b/lisp/c/sequence.c
@@ -142,7 +142,9 @@ pointer argv[];
     a=a->c.ary.entity;}
   if (isvector(a)) {
     count=vecsize(a);
-    if (n==3) e=min(e,count);
+    if (s>count) error(E_STARTEND);
+    if (n==3) {
+      if (e>count) error(E_STARTEND); }
     else e=count;
     count=e-s;
     switch(elmtypeof(a)) {


### PR DESCRIPTION
       since specifying start>end caused a segmentation fault.

This PR was once merged in https://github.com/euslisp/EusLisp/pull/285, but reverted https://github.com/euslisp/EusLisp/pull/293
because this causes huge regression for roseus https://github.com/jsk-ros-pkg/jsk_roseus/pull/568