### PR TITLE
[cl-compatible] Return T when AND has no arguments

### DIFF
--- a/lisp/c/specials.c
+++ b/lisp/c/specials.c
@@ -822,7 +822,7 @@ pointer arg;
 pointer AND(ctx,arg)	/*special form (should be macro)*/
 register context *ctx;
 register pointer arg;
-{ register pointer r;
+{ register pointer r = T;
 #ifdef SPEC_DEBUG
   printf( "AND:" ); hoge_print( arg );
 #endif


### PR DESCRIPTION
```lisp
(deftest and.1
  (and)
  t)
```