### PR TITLE
[cl-compatible] Return variable name in defparameter and defconstant

### DIFF
--- a/lisp/l/common.l
+++ b/lisp/l/common.l
@@ -137,11 +137,15 @@
 
 (defmacro defparameter (var init &optional (doc nil))
    (unless (symbolp var) (error 20))
-   `(send ',var :global ,init ,doc))
+   `(progn
+	(send ',var :global ,init ,doc)
+	',var))
 
 (defmacro defconstant (sym val &optional doc)
    (unless (symbolp sym) (error 20))
-   `(send ',sym :constant ,val ,doc) )
+   `(progn
+	(send ',sym :constant ,val ,doc)
+	',sym))
   
 
 (defmacro dotimes (vars &rest forms)


### PR DESCRIPTION
#299 and `defconstant`, similarly.

```
defconstant name initial-value [documentation] => name
```