### PR TITLE
Avoid deadlocks on qsort

### DIFF
--- a/lisp/c/sequence.c
+++ b/lisp/c/sequence.c
@@ -989,7 +989,7 @@ pointer argv[];
   if (seq==NIL) return(NIL);
 
 #if THREADED
-  mutex_lock(&qsort_lock);
+  mutex_trylock(&qsort_lock);
 #endif
   qsortctx=ctx;
   COMPAR=argv[1];


### PR DESCRIPTION
Fixes errors in:
```
(sort (list 1 2 3) #'elt)
(sort (list 1 2 3) #'>)
;; deadlock, euslisp crashes
```

Deadlock is caused by:
- Locking `qsort` on `sort` call
- Exiting on error, without unlocking the thread
- Trying to lock `qsort` again, on another `sort` call

Although this PR does not really unlock the thread in error cases, it seems to work fine for both the same thread (calling `sort` again) or other locks (e.g. calling `superequal`, which also uses `mutex_lock`) .

https://github.com/euslisp/ansi-test/issues/31
@ericlesaquiles 