### PR TITLE
enable to run compile-file with direcotry

### DIFF
--- a/lisp/comp/builtins.l
+++ b/lisp/comp/builtins.l
@@ -51,7 +51,7 @@
 (def-builtin-entry 'LISP:ASH "ASH")
 (def-builtin-entry 'LISP:LDB "LDB")
 (def-builtin-entry 'LISP:DPB "DPB")
-(def-builtin-entry 'LISP:MAKE-RANDOM-STATE "MAKE-RANDOM-STATE")
+(def-builtin-entry 'LISP:MAKE-RANDOM-STATE "MAKERANDOMSTATE")
 (def-builtin-entry 'LISP:RANDOM "RANDOM")
 (def-builtin-entry 'LISP:AREF "AREF")
 (def-builtin-entry 'LISP:ASET "ASET")

--- a/lisp/comp/comp.l
+++ b/lisp/comp/comp.l
@@ -1225,6 +1225,8 @@
 	 *verbose* verbose)
    (unless (send (pathname file) :directory)
      (setq file (namestring (merge-pathnames "./" file))))
+   (when (and (null o) (send (pathname file) :directory))
+     (setq o (send (pathname file) :directory-string)))
    (when o
 	   (setq o (pathname o))
 	   (setq o (merge-pathnames o file))


### PR DESCRIPTION
- currently  is valied but  is not Not sure why no body have ever complain
- C function name of make-random-state is MAKERANDOMSTATE
    the commit https://github.com/euslisp/EusLisp/pull/143 was not tested when the source is compiled