### PR TITLE
Arith.c fix

### DIFF
--- a/lisp/c/arith.c
+++ b/lisp/c/arith.c
@@ -815,9 +815,7 @@ pointer argv[];
   else if (pisbignum(a)) { rs=copy_big(a); goto bquo;}
   else error(E_NONUMBER);
 
-  if (n==1) {
-    fs=fltval(a);
-    return(makeflt(1.0/fs));}
+  if (n==1) return(makeflt(1.0/is));
 
   while (i<n) {
     a=argv[i];

--- a/lisp/c/arith.c
+++ b/lisp/c/arith.c
@@ -1157,6 +1157,8 @@ pointer LOGAND(context *ctx, int n, pointer argv[])
   eusinteger_t *rbv, *bbv, *pbv;
   pointer b,p,r=argv[0];
 
+  if (n==0) return(makeint(~0));
+
   if (isbignum(r)) {
     r=copy_big(r); rsize=bigsize(r); rbv=bigvec(r);
     p=argv[i++];

--- a/lisp/c/arith.c
+++ b/lisp/c/arith.c
@@ -1373,11 +1373,11 @@ pointer argv[];
 #else
   register unsigned int val,target,mask=~0;
 #endif
-  ckarg(4);
+  ckarg2(3,4);
   val=ckintval(argv[0]);
   target=ckintval(argv[1]);
   pos=ckintval(argv[2]);
-  width=ckintval(argv[3]);
+  if (n==4) width=ckintval(argv[3]);
   mask=mask<<(WORD_SIZE-(pos+width));
   mask=mask>>(WORD_SIZE-width); 
   val &= mask;

--- a/lisp/c/arith.c
+++ b/lisp/c/arith.c
@@ -702,6 +702,8 @@ register pointer argv[];
   for (i=0; i<n; i++) fprintf(stderr, "%x ", argv[i]);
   fprintf(stderr, "\n"); */
   
+  if (n==0) return(makeint(1));
+
   i=1;  
   a=argv[0];
   if (isint(a)) { is=intval(a); goto ITIMES;}


### PR DESCRIPTION
- **Fix quotient for one int argument**
before: `(/ 2) ;; inf`
after: `(/ 2) ;; 0.5`
- **Fix logand return value for zero arguments**
according to  jmanual, logand should be able to take zero arguments `(logand &rest integers)`.
before:  `(logand) ;;p=pointer?(0x503dbb8) 84138936`
after: `(logand) ;;-1`
-  **Make width an optional argument in `dpb`**
Same behaviour as `ldb`
-  **Fix * return value for zero arguments**
according to  jmanual, * should be able to take zero arguments `(* &rest numbers)`.
before: `(*) ;;error`
after: `(*) ;;1`

Changed from `master` to `cl-compatible`. #321