### PR TITLE
remove all compile warning including aarch64

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -100,6 +100,7 @@ fi
 if [[ "`uname -m`" == "arm"* || "`uname -m`" == "aarch"* ]]; then
     for test_l in irteus/test/*.l; do
         [[ $test_l =~ geo.l|interpolator.l|irteus-demo.l|test-irt-motion.l|object.l|coords.l|bignum.l|mathtest.l ]] && continue;
+        [[ "`uname -m`" == "aarch"* && $test_l =~ test-pointcloud.l ]] && continue;
 
         travis_time_start irteus.${test_l##*/}.test
 

--- a/.travis.sh
+++ b/.travis.sh
@@ -62,9 +62,10 @@ export DISPLAY=
 export EXIT_STATUS=0;
 set +e
 
-if [[ "`uname -m`" != "arm"* && "`uname -m`" != "aarch"* ]]; then
     # run test in EusLisp/test
     for test_l in $CI_SOURCE_PATH/test/*.l; do
+
+        [[ ("`uname -m`" == "arm"* || "`uname -m`" == "aarch"*) && $test_l =~ bignum.l|mathtest.l ]] && continue;
 
         travis_time_start euslisp.${test_l##*/}.test
 
@@ -76,14 +77,12 @@ if [[ "`uname -m`" != "arm"* && "`uname -m`" != "aarch"* ]]; then
         export EXIT_STATUS=`expr $TMP_EXIT_STATUS + $EXIT_STATUS`;
     done;
     echo "Exit status : $EXIT_STATUS";
-fi
 
-travis_time_end
 
-if [[ "`uname -m`" != "arm"* && "`uname -m`" != "aarch"* ]]; then
-    # run test in EusLisp/test
+    # run test in compiled EusLisp/test
     for test_l in $CI_SOURCE_PATH/test/*.l; do
         [[ $test_l =~ const.l ]] && continue;
+        [[ ("`uname -m`" == "arm"* || "`uname -m`" == "aarch"*) && $test_l =~ bignum.l|mathtest.l ]] && continue;
 
         travis_time_start compiled.${test_l##*/}.test
 
@@ -95,27 +94,12 @@ if [[ "`uname -m`" != "arm"* && "`uname -m`" != "aarch"* ]]; then
         export EXIT_STATUS=`expr $TMP_EXIT_STATUS + $EXIT_STATUS`;
     done;
     echo "Exit status : $EXIT_STATUS";
-fi
 
-if [[ "`uname -m`" == "arm"* || "`uname -m`" == "aarch"* ]]; then
-    for test_l in irteus/test/*.l; do
-        [[ $test_l =~ geo.l|interpolator.l|irteus-demo.l|test-irt-motion.l|object.l|coords.l|bignum.l|mathtest.l ]] && continue;
-        [[ "`uname -m`" == "aarch"* && $test_l =~ test-pointcloud.l ]] && continue;
-
-        travis_time_start irteus.${test_l##*/}.test
-
-        irteusgl $test_l;
-        export TMP_EXIT_STATUS=$?
-
-        travis_time_end `expr 32 - $TMP_EXIT_STATUS`
-
-        export EXIT_STATUS=`expr $TMP_EXIT_STATUS + $EXIT_STATUS`;
-    done;
-    echo "Exit status : $EXIT_STATUS";
-else
     # run test in jskeus/irteus
     for test_l in irteus/test/*.l; do
 
+        [[ ("`uname -m`" == "arm"* || "`uname -m`" == "aarch"*) && $test_l =~ geo.l|mathtest.l|interpolator.l|test-irt-motion.l|test-pointcloud.l ]] && continue;
+
         travis_time_start irteus.${test_l##*/}.test
 
         irteusgl $test_l;
@@ -126,7 +110,7 @@ else
         export EXIT_STATUS=`expr $TMP_EXIT_STATUS + $EXIT_STATUS`;
     done;
     echo "Exit status : $EXIT_STATUS";
-fi
+
 
 [ $EXIT_STATUS == 0 ] || exit 1
 

--- a/.travis.sh
+++ b/.travis.sh
@@ -53,6 +53,7 @@ travis_time_end
 
 travis_time_start script.make # All commands must exit with code 0 on success. Anything else is considered failure.
 cd jskeus
+make eus-installed MAKE='make -j4' ## try to run parallel, specially for arm
 make
 
 travis_time_end

--- a/.travis.sh
+++ b/.travis.sh
@@ -63,6 +63,11 @@ export DISPLAY=
 export EXIT_STATUS=0;
 set +e
 
+# arm target (ubuntu_arm64/trusty) takes too long time (>50min) for test
+if [[ "`uname -m`" == "aarch"* ]]; then
+    sed -i 's@00000@0000@' $CI_SOURCE_PATH/test/object.l $CI_SOURCE_PATH/test/coords.l
+fi
+
     # run test in EusLisp/test
     for test_l in $CI_SOURCE_PATH/test/*.l; do
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,17 @@ matrix:
       dist: trusty
       sudo: required
       cache: apt
+      env: DOCKER_IMAGE=debian:stretch
+    - os: linux
+      dist: trusty
+      sudo: required
+      cache: apt
       env: DOCKER_IMAGE=osrf/debian_arm64:jessie
+    - os: linux
+      dist: trusty
+      sudo: required
+      cache: apt
+      env: DOCKER_IMAGE=osrf/debian_arm64:stretch
     - os: osx
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,10 +85,10 @@ script:
 after_failure:
   - echo "failure"
 after_success:
-  - sudo apt-get install -qq -y texlive-latex-base ptex-bin latex2html nkf poppler-utils
-  - (cd doc/latex;  make; make html)
-  - (cd doc/jlatex; make; make html)
-  - git checkout doc/html/index.html # do not overwrite
+  - [[ "$DOCKER_IMAGE" == "ubuntu"* && "$ROS_DISTRO" == "" ]] && sudo apt-get install -qq -y texlive-latex-base ptex-bin latex2html nkf poppler-utils
+  - [[ "$DOCKER_IMAGE" == "ubuntu"* && "$ROS_DISTRO" == "" ]] && (cd doc/latex;  make; make html)
+  - [[ "$DOCKER_IMAGE" == "ubuntu"* && "$ROS_DISTRO" == "" ]] && (cd doc/jlatex; make; make html)
+  - [[ "$DOCKER_IMAGE" == "ubuntu"* && "$ROS_DISTRO" == "" ]] && git checkout doc/html/index.html # do not overwrite
 deploy:
   provider: releases
   api_key: "$GH_TOKEN"

--- a/lisp/c/arith.c
+++ b/lisp/c/arith.c
@@ -15,6 +15,7 @@ static char *rcsid="@(#)$Id$";
 #if Cygwin
 #include <stdlib.h>
 #endif
+extern int ffsl(long int i); // #include <string.h> // ffsl
 
 extern pointer RANDSTATE;
 extern int gcd();
@@ -86,7 +87,7 @@ pointer NUMNEQUAL(ctx,n,argv)
 register context *ctx;
 register int n;
 register pointer argv[];
-{ register i;
+{ register int i;
   pointer cmparr[2];
   numunion nu;
 
@@ -1104,7 +1105,7 @@ register context *ctx;
 register int  n;
 pointer argv[];
 { eusfloat_t fs,fm;
-  register i=1;
+  register int i=1;
   register eusinteger_t is;
   register pointer a=argv[0];
   numunion nu;

--- a/lisp/c/calleus.c
+++ b/lisp/c/calleus.c
@@ -55,7 +55,7 @@ cixpair foreignpodcp;
 			    		  ((p)->cix)<=foreignpodcp.sub)
 #define isforeignpod(p) (ispointer(p) && pisforeignpod(p))
 
-#if x86_64
+#if (defined x86_64) || (defined aarch64)
 // Linux, x64
 /* development version of euscall written by Y.Kakiuchi */
 union NUMCONVBUF {

--- a/lisp/c/compsub.c
+++ b/lisp/c/compsub.c
@@ -11,7 +11,7 @@ static char *rcsid="@(#)$Id$";
 
 #include "eus.h"
 
-maerror()
+int maerror()
 { error(E_MISMATCHARG);}
 
 pointer loadglobal(s)

--- a/lisp/c/eus.c
+++ b/lisp/c/eus.c
@@ -26,8 +26,8 @@ unsigned int thr_self() { return(1);}
 #endif
 
 
-#if Linux
-#define M_MMAP_MAX (-4)
+#if Linux && !OLD_LINUX && !Darwin
+#include <malloc.h> // define mallopt, M_MMAP_MAX
 #endif
 #if Darwin
 int _end;
@@ -1023,7 +1023,7 @@ char *prompt;
 { jmp_buf brkjmp;
   pointer val;
   int i;
-  mkcatchframe(ctx,T,brkjmp);
+  mkcatchframe(ctx,T,&brkjmp);
   Spevalof(QSTDOUT)=STDOUT;
   Spevalof(QSTDIN)=STDIN;
   Spevalof(QERROUT)=ERROUT;
@@ -1105,7 +1105,7 @@ char *argv[];
       ufuncall(ctx,topform,topform,(pointer)(ctx->vsp-argc),0,argc);}
     else ufuncall(ctx,topform,topform,(pointer)(ctx->vsp),0,0);}
   else { /*TOPLEVEL not yet defined-- try built-in toplevel*/
-    mkcatchframe(ctx,makeint(0),topjbuf);
+    mkcatchframe(ctx,makeint(0),&topjbuf);
     fprintf(stderr, "entering reploop\n");
     reploop(ctx,": ");}
   }
@@ -1154,7 +1154,7 @@ register context *ctx;
   else strcpy(fname, eusrt);
   if (isatty(0)!=0) {
     fprintf(stderr, "configuring by \"%s\"\n", fname); }
-  mkcatchframe(ctx,makeint(0), topjbuf);
+  mkcatchframe(ctx,makeint(0),&topjbuf);
   argv=makestring(fname, strlen(fname));
   vpush(argv);
   eusstart(ctx);
@@ -1256,7 +1256,7 @@ register context *ctx;
 #endif
   }
 
-main(argc,argv)
+int main(argc,argv)
 int argc;
 char *argv[];
 { int i, stat=0;

--- a/lisp/c/eus_proto.h
+++ b/lisp/c/eus_proto.h
@@ -91,7 +91,7 @@ extern pointer normalize_bignum(pointer /*x*/);
 extern eusfloat_t big_to_float(pointer /*x*/);
 /* big2.c */
 /* calleus.c */
-#if x86_64
+#if (defined(x86_64) || defined(aarch64))
 extern eusinteger_t calleus(pointer /*fsym*/, eusinteger_t /*cargv*/*);
 #else
 extern eusinteger_t calleus(pointer /*fsym*/, eusinteger_t /*cargv*/*, int /*a2*/, int /*a3*/, int /*a4*/, int /*a5*/, int /*a6*/, int /*a7*/, int /*a8*/);

--- a/lisp/c/eusioctl.c
+++ b/lisp/c/eusioctl.c
@@ -38,6 +38,7 @@ pointer x;
 
 static pointer ioctl_struct(n,argv,ctlcode,bufsize)
 int n,bufsize;
+unsigned long  ctlcode;
 pointer argv[];
 { int fd,stat;
   pointer buf;
@@ -50,6 +51,7 @@ pointer argv[];
 
 static pointer ioctl_int(n,argv,ctlcode)
 int n;
+unsigned long  ctlcode;
 pointer argv[];
 { int fd,stat,intarg;
   pointer buf;

--- a/lisp/c/eusstream.c
+++ b/lisp/c/eusstream.c
@@ -68,7 +68,7 @@ pointer s;
 /* read primitive
 /****************************************************************/
 
-static fillstream(s)
+static int fillstream(s)
 register pointer s;
 { register int c;
   pointer lsave;

--- a/lisp/c/eval.c
+++ b/lisp/c/eval.c
@@ -1163,7 +1163,11 @@ register int noarg;
 #endif
 #if ARM
   if (func->c.code.entry2 != NIL) {
+#if (WORD_SIZE == 64)
+    addr = addr | (intval(func->c.code.entry2)&0x00000000ffffffff);
+#else
     addr = addr | (intval(func->c.code.entry2)&0x0000ffff);
+#endif
   }
 #endif
   subr=(pointer (*)())(addr);
@@ -1258,7 +1262,11 @@ int noarg;
     clofunc=func;
     fn=func;
     if (fn->c.code.subrtype!=SUBR_FUNCTION) error(E_ILLFUNC);
+#if (WORD_SIZE == 64)
+    subr=(pointer (*)())((eusinteger_t)(fn->c.code.entry) & ~3L /*0xfffffffc ????*/);
+#else
     subr=(pointer (*)())((eusinteger_t)(fn->c.code.entry) & ~3 /*0xfffffffc ????*/);
+#endif
 #if ARM
     register eusinteger_t addr;
     addr = (eusinteger_t)(fn->c.code.entry);
@@ -1268,7 +1276,11 @@ int noarg;
     addr &= ~3;  /*0xfffffffc; ???? */
 #endif
     if (fn->c.code.entry2 != NIL) {
+#if (WORD_SIZE == 64)
+      addr = addr | (intval(fn->c.code.entry2)&0x00000000ffffffff);
+#else
       addr = addr | (intval(fn->c.code.entry2)&0x0000ffff);
+#endif
     }
     subr=(pointer (*)())(addr);
 #endif

--- a/lisp/c/eval.c
+++ b/lisp/c/eval.c
@@ -1156,8 +1156,8 @@ register int noarg;
   register eusinteger_t addr;
   pointer tmp;
   addr=(eusinteger_t)(func->c.code.entry);
-#if (defined x86_64) || (defined aarch64)
-  addr &= ~3L;  /*0xfffffffc; ???? */
+#if (WORD_SIZE == 64)
+  addr &= ~3L;  /*0xfffffffffffffffc; ???? */
 #else
   addr &= ~3;  /*0xfffffffc; ???? */
 #endif

--- a/lisp/c/eval.c
+++ b/lisp/c/eval.c
@@ -430,7 +430,7 @@ bindaux:
 evbody:
     GC_POINT;
     /*create block around lambda*/
-    myblock=(struct blockframe *)makeblock(ctx,BLOCKFRAME,fn,(jmp_buf *)funjmp,NULL);
+    myblock=(struct blockframe *)makeblock(ctx,BLOCKFRAME,fn,&funjmp,NULL);
     /*evaluate body*/
     if ((result=(pointer)eussetjmp(funjmp))==0) {GC_POINT;result=progn(ctx,body);}
     else if (result==(pointer)1) result=makeint(0);
@@ -889,8 +889,8 @@ pointer args[];
   double f;
 
   if (code->c.fcode.entry2 != NIL) {
-    ifunc = (((eusinteger_t)ifunc)&0xffffffff00000000) 
-      | (intval(code->c.fcode.entry2)&0x00000000ffffffff);
+    ifunc = (eusinteger_t (*)())((((eusinteger_t)ifunc)&0xffffffff00000000)
+      | (intval(code->c.fcode.entry2)&0x00000000ffffffff));
     /* R.Hanai 090726 */
   }
   

--- a/lisp/c/fcall.c
+++ b/lisp/c/fcall.c
@@ -31,7 +31,11 @@ pointer (**fslot)();
 #endif
 #if ARM
     if (fn->c.code.entry2 != NIL) {
+#if (WORD_SIZE == 64)
+      x = x | (intval(fn->c.code.entry2)&0x00000000ffffffff);
+#else
       x = x | (intval(fn->c.code.entry2)&0x0000ffff);
+#endif
     }
 #endif
     subr=(pointer (*)())(x);

--- a/lisp/c/fstringdouble.c
+++ b/lisp/c/fstringdouble.c
@@ -393,7 +393,7 @@ pointer argv[];
   return (vpop());
 }
 #endif
-fstringdouble(ctx,n,argv)
+int fstringdouble(ctx,n,argv)
 context *ctx;
 int n;
 pointer argv[];

--- a/lisp/c/helpsub.c
+++ b/lisp/c/helpsub.c
@@ -8,7 +8,7 @@ static char *rcsid="@(#)$Id$";
 
 #pragma init (init_object_module)
 extern pointer helpsub();
-static init_object_module()
+static void init_object_module()
   { add_module_initializer("helpsub", helpsub);}
 
 
@@ -36,10 +36,11 @@ static char READ_CHAR(fd)
 int fd;
 {
   char c;
+  int r;
 
   if ((bp == -1) || (bp == BUFSIZE)){
     bp=0;
-    GC_REGION(read(fd, &buf[0], BUFSIZE););
+    GC_REGION(r=read(fd, &buf[0], BUFSIZE););
   }
   c=buf[bp];
   bp++;
@@ -147,7 +148,7 @@ pointer argv[];
           }
         }
   }
-  *sp=NULL;
+  *sp=0;
   j=strlen(str);
   s=makestring(&str[0],j);
   return(s);

--- a/lisp/c/lispio.c
+++ b/lisp/c/lispio.c
@@ -379,6 +379,7 @@ pointer argv[];
 
 pointer GETMACROCH(ctx,n,argv)
 register context *ctx;
+int n;
 pointer argv[];
 { pointer rdtable;
   ckarg2(1,2);

--- a/lisp/c/loadelf.c
+++ b/lisp/c/loadelf.c
@@ -113,7 +113,7 @@ register context *ctx;
       addr= addr>>2;
       mod->c.ldmod.entry=makeint(addr);
 #if ARM
-      mod->c.ldmod.entry2=makeint(initfunc);
+      mod->c.ldmod.entry2=makeint((eusinteger_t)initfunc);
 #endif
       mod->c.ldmod.subrtype=SUBR_ENTRY;
       (*initfunc)(ctx,1, &mod); }
@@ -180,7 +180,7 @@ pointer initnames;
       mod->c.ldmod.codevec=makeint(0);
       mod->c.ldmod.entry=makeint(addr);
 #if ARM
-      mod->c.ldmod.entry2=makeint(initfunc);
+      mod->c.ldmod.entry2=makeint((eusinteger_t)initfunc);
 #endif
       mod->c.ldmod.subrtype=SUBR_FUNCTION;
       p=cons(ctx,mod, NIL);
@@ -231,7 +231,7 @@ pointer *argv;
       mod->c.ldmod.codevec=makeint(0);
       mod->c.ldmod.entry=makeint(addr);
 #if ARM
-      mod->c.ldmod.entry2=makeint(initfunc);
+      mod->c.ldmod.entry2=makeint((eusinteger_t)initfunc);
 #endif
       mod->c.ldmod.subrtype=SUBR_FUNCTION;
       p=cons(ctx,mod, NIL);
@@ -409,7 +409,7 @@ pointer *argv;
     mod->c.ldmod.codevec=makeint(0);
     mod->c.ldmod.entry=makeint(addr);
 #if ARM
-    mod->c.ldmod.entry2=makeint(initfunc);
+    mod->c.ldmod.entry2=makeint((eusinteger_t)initfunc);
 #endif
     mod->c.ldmod.subrtype=SUBR_FUNCTION;
     (*initfunc)(ctx, 1, &mod); }

--- a/lisp/c/makes.c
+++ b/lisp/c/makes.c
@@ -292,7 +292,7 @@ pointer (*f)();
   fentaddr= (eusinteger_t)f>>2;
   cd->c.code.entry=makeint(fentaddr);
 #if ARM
-  cd->c.code.entry2=makeint(f);
+  cd->c.code.entry2=makeint((eusinteger_t)f);
 #endif
   return(cd);}
 
@@ -513,7 +513,7 @@ pointer (*f)();
   clo->c.clo.subrtype=SUBR_FUNCTION;
   clo->c.clo.entry=makeint((eusinteger_t)f>>2);
 #if ARM
-  clo->c.clo.entry2=makeint(f);
+  clo->c.clo.entry2=makeint((eusinteger_t)f);
 #endif
   clo->c.clo.env0=e0;
   clo->c.clo.env1=e1; /*makeint((int)e1>>2);*/

--- a/lisp/c/makes.c
+++ b/lisp/c/makes.c
@@ -906,6 +906,7 @@ int bs_size;
   return(cntx);}
 
 void deletecontext(id,ctx)
+int id;
 register context *ctx;
 { if (id<MAXTHREAD) euscontexts[id]=NULL;
   cfree(ctx->stack);

--- a/lisp/c/matrix.c
+++ b/lisp/c/matrix.c
@@ -902,7 +902,7 @@ pointer argv[];
 /*		worldp: nil--local(mult rot mat from the right)
 /*			t----world(mult rot mat from the left)
 /****************************************************************/
-static copymat(dest,src,size)
+static void copymat(dest,src,size)
 pointer dest,src;
 register int size;
 { register int i;
@@ -1285,7 +1285,7 @@ pointer argv[];
   if (stat<0) return(NIL);
   else return(pv);}
 
-static solve(a,pv,s,b,x)
+static void solve(a,pv,s,b,x)
 register eusfloat_t *a;
 pointer b,x,pv;
 int s;

--- a/lisp/c/memory.c
+++ b/lisp/c/memory.c
@@ -33,7 +33,7 @@ static char *rcsid="@(#)$Id$";
 
 /* Written by I.Hara 01/12/95 */
 #if Solaris2 || Linux
-extern _end();
+extern eusinteger_t _end();
 #elif SunOS4_1
 extern edata;
 #else
@@ -62,7 +62,7 @@ long alloccount[MAXBUDDY];
 static  pointer dispose[MAXDISPOSE];
 static  int dispose_count;
 
-newchunk(k)
+int newchunk(k)
 register int k;
 { register int s;
   register struct chunk *cp;  
@@ -708,7 +708,7 @@ register int gcmerge;
         p=np;} } }
   }  
 
-call_disposers()
+void call_disposers()
 { int i;
   context *ctx=current_ctx;
   pointer p,a,curclass;
@@ -744,7 +744,7 @@ void sweepall()
   }
 
 #if THREADED
-suspend_all_threads()
+void suspend_all_threads()
 { register int i, self, stat;
   
   self=thr_self();
@@ -754,7 +754,7 @@ suspend_all_threads()
       if (stat) fprintf(stderr, "gc cannot suspend thread %d\n",i);  }
   }
 
-resume_all_threads()
+void resume_all_threads()
 { register int i, self, stat;
   
   self=thr_self();

--- a/lisp/c/memory.c
+++ b/lisp/c/memory.c
@@ -47,8 +47,10 @@ static eusinteger_t top_addr, bottom_addr;
 extern pointer QPARAGC;
 extern pointer K_DISPOSE;
 
-char *maxmemory=(char *)0x100000;
-#if Cygwin
+char *maxmemory=(char *)0x0;
+#if (WORD_SIZE == 64)
+char *minmemory=(char *)0xffffffffffffffff;
+#else
 char *minmemory=(char *)0xffffffff;
 #endif
 long freeheap=0,totalheap=0;	/*size of heap left and allocated*/
@@ -81,11 +83,8 @@ register int k;
   set_heap_range((unsigned int)cp,
       (unsigned int)cp + (s+2)*sizeof(pointer)+(sizeof(pointer)-1));
 #endif
-#if Cygwin
+#if Linux || Cygwin || Darwin
   if (minmemory > (char *)cp) minmemory = (char *)cp;
-  if (maxmemory < (char *)sbrk(0)) maxmemory = (char *)sbrk(0);
-  if (maxmemory < (char *)cp+(s+2)*sizeof(pointer)+(sizeof(pointer)-1)) maxmemory = ((char *)cp+(s+2)*sizeof(pointer)+(sizeof(pointer)-1));
-#elif Linux
   if (maxmemory < (char *)sbrk(0)) maxmemory = (char *)sbrk(0);
   if (maxmemory < (char *)cp+(s+2)*sizeof(pointer)+(sizeof(pointer)-1)) maxmemory = ((char *)cp+(s+2)*sizeof(pointer)+(sizeof(pointer)-1));
 #else
@@ -415,16 +414,13 @@ pointer *gcstack, *gcsplimit, *gcsp;
 #if Solaris2 
 #define out_of_heap(p) ((int)p<(int)_end || (pointer)0x20000000<p)
 #else /* Solaris2 */
-#if Linux
+#if Linux || Cygwin || Darwin
 #if (WORD_SIZE == 64)
-#define out_of_heap(p) ((unsigned long)p<(unsigned long)_end || (pointer)maxmemory <p)
+#define out_of_heap(p) ((unsigned long)p<(unsigned long)minmemory || (pointer)maxmemory <p)
 #else
-#define out_of_heap(p) ((unsigned int)p<(unsigned int)_end || (pointer)maxmemory <p)
-#endif
-#else /* Linux */
-#if Cygwin /* Cygwin does not have _end */ || Darwin
 #define out_of_heap(p) ((unsigned int)p<(unsigned int)minmemory || (pointer)maxmemory <p)
-#else /* Cygwin */
+#endif
+#else /* Linux || Cygwin || Darwin */
 #if alpha
 #if THREADED
 #define out_of_heap(p) ((long)p<4 || bottom_addr<(long)p)
@@ -442,8 +438,7 @@ pointer *gcstack, *gcsplimit, *gcsp;
 #endif
 #endif /* SunOS4_1 */
 #endif /* alpha */
-#endif /* Linux */
-#endif /* Cygwin */
+#endif /* Linux || Cygwin || Darwin */
 #endif /* Solaris2 */
 
 

--- a/lisp/c/mthread.c
+++ b/lisp/c/mthread.c
@@ -53,7 +53,7 @@ pointer port;
   ctx=(context *)((eusinteger_t)port->c.thrp.contex & ~2L);
   euscontexts[tid]=ctx;
 /*  fprintf(stderr, "new thread %d port=%x ctx=%x\n", tid, port, ctx); */
-  mkcatchframe(ctx, makeint(0), thjmp);
+  mkcatchframe(ctx, makeint(0),&thjmp);
   mutex_lock(&free_thread_lock);
     free_threads=cons(ctx,port, free_threads);
   mutex_unlock(&free_thread_lock);
@@ -425,7 +425,7 @@ struct thread_arg *ta;
   tid=thr_self();
   euscontexts[tid]=ta->newctx;
   fprintf(stderr,"new thread_id=%d\n",tid);
-  mkcatchframe(ta->newctx, makeint(0), thjmp);
+  mkcatchframe(ta->newctx, makeint(0),&thjmp);
   if ((val=(pointer)eussetjmp(thjmp))==0) {
     argv[0]=ta->arg;
     result=ufuncall(ta->newctx, ta->form, ta->func,(pointer)argv,NULL,1);}
@@ -533,7 +533,7 @@ pointer argv[];
   }
 #endif  
 
-mthread(ctx,mod)
+int mthread(ctx,mod)
 register context *ctx;
 pointer mod;
 {

--- a/lisp/c/printer.c
+++ b/lisp/c/printer.c
@@ -31,7 +31,7 @@ static char ixbuf[16];
 extern enum ch_type chartype[256];
 extern enum ch_attr charattr[256];
 
-static print_symbol_prefix(ctx,f,pkg,colon)
+static void print_symbol_prefix(ctx,f,pkg,colon)
 context *ctx;
 register pointer f,pkg;
 char *colon;
@@ -47,7 +47,7 @@ char *colon;
   writestr(f,(byte *)colon,strlen(colon));}
 
 
-static pointer symprefix(sym,f)
+static void symprefix(sym,f)
 register pointer sym,f;
 { register int l,c;
   register byte *s;
@@ -209,14 +209,14 @@ pointer f;
       while (len>2 && work[len-1]=='0' && work[len-2]!='.') len--;} 
     writestr(f,(byte *)work,len); }}
 
-static printhex(val,f)
+static void printhex(val,f)
 int val;
 pointer f;
 { char work[20];
   sprintf(work,"#x%x",val);
   writestr(f,(byte *)work,strlen(work));}
 
-static printratio(ctx,rat,f, base)
+static void printratio(ctx,rat,f, base)
 context *ctx;
 pointer rat,f;
 int base;
@@ -227,7 +227,7 @@ int base;
 
 extern pointer big_minus(), copy_big();
 
-static printbig(ctx, big, f, base, field1,field2)
+static void printbig(ctx, big, f, base, field1,field2)
 context *ctx;
 pointer big,f;
 int base, field1,field2;
@@ -454,9 +454,10 @@ int prlevel,rank,axis,index;
   writech(f,')');
   return(n);}
 
-static printarray(ctx,a,f,prlevel)
+static void printarray(ctx,a,f,prlevel)
 register context *ctx;
 register pointer a,f;
+register int prlevel;
 { char buf[16];
   register int i,j,rank,etype,size=1,index;
   register pointer p,v;

--- a/lisp/c/reader.c
+++ b/lisp/c/reader.c
@@ -261,7 +261,7 @@ eusinteger_t labx;
     pointer_update(*unsolp,result); }
   return(result);}
 
-static addunsolved(labp,addr)
+static void addunsolved(labp,addr)
 pointer labp;
 pointer *addr;
 { pointer_update(*addr,labp->c.lab.unsolved);
@@ -276,6 +276,7 @@ pointer *addr;
 }
 
 static pointer readlabref(ctx,f,val,subchar)
+register context *ctx;
 pointer f;
 eusinteger_t val;
 int subchar;
@@ -766,7 +767,7 @@ int len;
   ctx->lastalloc= vpop();
   return(b);}
 
-is_digit(ch,base)
+int is_digit(ch,base)
 register int ch,base;
 { if (ch<'0') return(FALSE);
   if (base<=10)
@@ -823,12 +824,15 @@ pointer f;
   return(cons(ctx,QUOTE,cons(ctx,q,NIL)));}
 
 static pointer readcomment(ctx,f)
+register context *ctx;
 pointer f;
 { register Char ch;
   do { ch=readch(f);} while (ch!='\n' && ch!=EOF);
   return(UNBOUND);}
 
 static pointer readrparen(ctx,f)
+register context *ctx;
+pointer f;
 { return(UNBOUND);}
 
 

--- a/lisp/c/specials.c
+++ b/lisp/c/specials.c
@@ -172,7 +172,11 @@ register pointer argv[];
 #else
     addr &= ~3;  /*0xfffffffc; ???? */
 #endif
+#if (WORD_SIZE == 64)
+    addr = addr | (intval(mac->c.code.entry2)&0x00000000ffffffff);
+#else
     addr = addr | (intval(mac->c.code.entry2)&0x0000ffff);
+#endif
 #endif // ARM
     if (mac->c.code.subrtype!=(pointer)SUBR_MACRO) return(argv[0]);
 #if ARM

--- a/lisp/c/specials.c
+++ b/lisp/c/specials.c
@@ -373,7 +373,7 @@ pointer arg;
   if (!islist(arg)) return(NIL);
   cond=ccar(arg); body=ccdr(arg);
   myblock=(struct blockframe *)
-		makeblock(ctx,BLOCKFRAME,NIL,(jmp_buf *)whilejmp,ctx->blkfp); /* ???? */
+		makeblock(ctx,BLOCKFRAME,NIL,&whilejmp,ctx->blkfp); /* ???? */
   if ((result=(pointer)eussetjmp(whilejmp))==0) {
     while (eval(ctx,cond)!=NIL) {GC_POINT;progn(ctx,body);}
     result=NIL;}
@@ -513,7 +513,7 @@ pointer arg;
 
   tag=carof(arg,E_MISMATCHARG); tag=eval(ctx,tag);
   body=ccdr(arg);
-  mkcatchframe(ctx,tag,catchbuf);
+  mkcatchframe(ctx,tag,&catchbuf);
   if ((val=(pointer)eussetjmp(catchbuf))==0) val=progn(ctx,body);
   else if ((eusinteger_t)val==1) val=makeint(0);	/*longjmp cannot return 0*/
   ctx->callfp=ctx->catchfp->cf;
@@ -654,7 +654,7 @@ register pointer arg;		/*must be called via ufuncall*/
   GC_POINT;
   name=carof(arg,E_MISMATCHARG); arg=ccdr(arg);
   if (!issymbol(name)) error(E_NOSYMBOL);
-  myblock=(struct blockframe *)makeblock(ctx,BLOCKFRAME,name,(jmp_buf *)blkjmp,ctx->blkfp); /* ???? */
+  myblock=(struct blockframe *)makeblock(ctx,BLOCKFRAME,name,&blkjmp,ctx->blkfp); /* ???? */
   if ((result=(pointer)eussetjmp(blkjmp))==0) result=progn(ctx,arg);
   else if ((eusinteger_t)result==1) result=makeint(0);
   ctx->blkfp=myblock->dynklink;
@@ -746,7 +746,7 @@ pointer arg;
     if (!iscons(ccar(p))) golist=cons(ctx,p,golist);
     p=ccdr(p);}
   tagblock=(struct blockframe *)
-	makeblock(ctx,TAGBODYFRAME,golist,(jmp_buf*)tagjmp,ctx->blkfp); /* ???? */
+	makeblock(ctx,TAGBODYFRAME,golist,&tagjmp,ctx->blkfp); /* ???? */
   tagspsave=ctx->vsp;
 repeat:
   if ((p=(pointer)eussetjmp(tagjmp))==0) 
@@ -775,7 +775,7 @@ pointer arg;
     if (ctx->blkfp->kind==TAGBODYFRAME &&
 	(body=(pointer)assq(tag,ctx->blkfp->name))!=NIL) {
       unwind(ctx,(pointer *)ctx->blkfp);
-      euslongjmp(ctx->blkfp->jbp,body);}/* ???? */
+      euslongjmp(*(ctx->blkfp->jbp),body);}/* ???? */
       /* euslongjmp(*(ctx->blkfp->jbp),body);} *//* ??? eus_rbar */
     ctx->blkfp=ctx->blkfp->lexklink;}
   error(E_USER,(pointer)"go tag not found");}

--- a/lisp/c/sysfunc.c
+++ b/lisp/c/sysfunc.c
@@ -66,6 +66,7 @@ pointer argv[];
 
 pointer NEWSTACK(ctx,n,argv)
 context *ctx;
+int n;
 pointer argv[];
 { eusinteger_t newsize;
   if (n==0) return(makeint((ctx->stacklimit+100-ctx->stack)));
@@ -78,6 +79,7 @@ pointer argv[];
 
 pointer DISPOSE_HOOK(ctx,n,argv)
 context *ctx;
+int n;
 pointer argv[];
 { 
 #ifndef RGC
@@ -97,10 +99,10 @@ pointer argv[];
 #if Solaris2
 extern _end();
 #else
-extern edata();
+extern eusinteger_t edata();
 #endif
 
-xmark(ctx,p)
+int xmark(ctx,p)
 register context *ctx;
 register pointer p;
 { register int s;
@@ -287,6 +289,7 @@ pointer x;
 
 pointer OBJSIZE(ctx,n,argv)
 register context *ctx;
+int n;
 pointer argv[];
 { register pointer a=argv[0];
   ckarg2(1,2);

--- a/lisp/c/unixcall.c
+++ b/lisp/c/unixcall.c
@@ -126,6 +126,7 @@ pointer argv[];
 
 pointer LOCALTIME(ctx,n,argv)
 register context *ctx;
+int n;
 pointer argv[];
 { long clock;
   struct tm *tms;

--- a/lisp/tool/gccls.c
+++ b/lisp/tool/gccls.c
@@ -25,7 +25,7 @@
 
 static char buf[MAX_LINE_SIZE];
 
-main(argc,argv)
+int main(argc,argv)
 int argc;
 char *argv[];
 {
@@ -56,7 +56,7 @@ char *argv[];
   fprintf(out, "extern void add_module_initializer();\n");
 #endif
   fprintf(out, "extern void %s();\n", entryname);
-  fprintf(out, "static init_object_module()\n");
+  fprintf(out, "static void init_object_module()\n");
   fprintf(out, "  {add_module_initializer(\"%s\", (pointer (*)())%s);}\n", entryname, entryname);
   fprintf(out, "const static char *sexp_strings[NUM_LINES]={\n");
 


### PR DESCRIPTION
- use WORD_SIZE instaed of aarch64 and x86_64
- use calleus with argument for aarch64
- cast eusintegert_t, use 0x00000000ffffffff instead of 0x0000ffff for  aarch64
- remove all compile warning for eus0 set return value use jmp_buf pointer  for longjmp

- 8707c49 run after_sucess only for DOCKER_IMAGE == ubuntu* to save time
- 851d5a9 some arm target (ubuntu_arm64/trusty) takes too long time (>50min) for test
- 92db3cd cleanup .travis.sh
- f5c3a6e skip test-pointcloud.l for aarch64
- b937577 use minmemory, instead of _end
- 1bd5acc add debian/stretch tests for x86_64 and aarch64
