### PR TITLE
Raise less errors on read_cond

### DIFF
--- a/lisp/c/reader.c
+++ b/lisp/c/reader.c
@@ -594,9 +594,10 @@ register pointer f;
 { register pointer flag,result;
   flag=read1(ctx,f);
   vpush(flag);
-  read_suppress=TRUE;
-  result=read1(ctx,f);
-  if (eval_read_cond(ctx,flag)==NIL) result=(pointer)UNBOUND;
+  if (eval_read_cond(ctx,flag)==NIL) {
+    read_suppress=TRUE; read1(ctx,f);
+    result=(pointer)UNBOUND;}
+  else result=read1(ctx,f);
   vpop();
   return(result);}
 
@@ -606,9 +607,10 @@ register pointer f;
 { register pointer flag,result;
   flag=read1(ctx,f);
   vpush(flag);
-  read_suppress=TRUE;
-  result=read1(ctx,f);
-  if (eval_read_cond(ctx,flag)!=NIL) result=(pointer)UNBOUND;
+  if (eval_read_cond(ctx,flag)!=NIL) {
+    read_suppress=TRUE; read1(ctx,f);
+    result=(pointer)UNBOUND;}
+  else result=read1(ctx,f);
   vpop();
   return(result);}
 


### PR DESCRIPTION
Avoid `read_cond` to raise some errors such as in:
```lisp
#-:eus test:this
;; error: no such package TEST
```
This will become crucial when adapting common lisp code to eus with `read_cond` clauses.

--
This PR makes the following tests pass: 
```
read-suppress.1
read-suppress.3
read-suppress.4
read-suppress.17
read-suppress.sharp-left-paren.6
read-suppress.sharp-left-paren.7
read-suppress.sharp-left-paren.8
read-suppress.sharp-left-paren.9
read-suppress.sharp-left-paren.10
read-suppress.sharp-dot.2
read-suppress.sharp-dot.3
read-suppress.sharp-o.3
read-suppress.sharp-o.4
read-suppress.sharp-o.5
read-suppress.sharp-o.6
read-suppress.sharp-o.9
read-suppress.sharp-o.10
read-suppress.sharp-s.2
read-suppress.sharp-s.3
read-suppress.sharp-s.4
read-suppress.sharp-equal.1
read-suppress.sharp-equal.2
read-suppress.sharp-equal.3
read-suppress.sharp-equal.4
read-suppress.sharp-sharp.1
read-suppress.sharp-sharp.2
read-suppress.sharp-sharp.3
read-suppress.sharp-sharp.4
```