### PR TITLE
if (float-vector 792.732209445) trated to local[1]= makeflt(7.92732209e+02), it reduces precisio

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -170,7 +170,7 @@ fi
     # run test in jskeus/irteus
     for test_l in irteus/test/*.l; do
 
-        [[ ("`uname -m`" == "arm"* || "`uname -m`" == "aarch"*) && $test_l =~ geo.l|mathtest.l|interpolator.l|test-irt-motion.l|test-pointcloud.l|irteus-demo.l ]] && continue;
+        [[ ("`uname -m`" == "arm"* || "`uname -m`" == "aarch"*) && $test_l =~ geo.l|mathtest.l|interpolator.l|test-irt-motion.l|irteus-demo.l ]] && continue;
 
         travis_time_start irteus.${test_l##*/}.test
 

--- a/test/mathtest.l
+++ b/test/mathtest.l
@@ -152,6 +152,13 @@
     (format *error-output* "~A ~A~%" (+ (expt 2 32) 1234) (abs (+ (expt 2 32) 1234)))
     ))
 
+(deftest compile-float-vector
+  ;; if (float-vector 792.732209445) translated to local[1]= makeflt(7.92732209e+02), it reduces precision
+  (warning-message 2 "#f(792.732209445) ~A~%" #f(792.732209445))
+  (warning-message 2 "(float-vector 792.732209445) ~A~%" (float-vector 792.732209445))
+  (assert (< (norm (v- #f(792.732209445) (float-vector 792.732209445))) 1.0e-7)
+	  (format nil "(norm (v- #f(792.732209445) (float-vector 792.732209445))) should be zero, but ~A~%" (norm (v- #f(792.732209445) (float-vector 792.732209445))))))
+
 (eval-when (load eval)
   (run-all-tests)
   (exit))


### PR DESCRIPTION
if `(float-vector 792.732209445)` translated to `local[1]= makeflt(7.92732209e+02)`, it reduces precision