### PR TITLE
Use (arglist . docstring) pair as function documentation

### DIFF
--- a/lisp/c/leo.c
+++ b/lisp/c/leo.c
@@ -157,8 +157,11 @@ pointer arg;
     if (ccar(ccdr(method)) == NIL) {
       arglist = makestring("()",2);}
     else {
+      pointer osf=ctx->slashflag;
       arglist=(pointer)mkstream(ctx,K_OUT,makebuffer(256));
+      ctx->slashflag=1;
       prinx(ctx,ccar(ccdr(method)),arglist);
+      ctx->slashflag=osf;
       arglist=makestring((char *)arglist->c.stream.buffer->c.str.chars,intval(arglist->c.stream.count));}
     doc=ccdr(ccdr(method)); /* body */
     if (isstring(ccar(doc)) && ccdr(doc) != NIL) {

--- a/lisp/c/specials.c
+++ b/lisp/c/specials.c
@@ -1098,7 +1098,7 @@ pointer *argv;
 pointer DEFUN(ctx,arg)
 register context *ctx;
 pointer arg;
-{ pointer funcname;
+{ pointer funcname,doc;
   extern pointer putprop();
 #ifdef SPEC_DEBUG
   printf( "DEFUN:" ); hoge_print( arg );
@@ -1107,15 +1107,24 @@ pointer arg;
   arg=ccdr(arg);
   if (issymbol(funcname)) {pointer_update(funcname->c.sym.spefunc,cons(ctx,LAMBDA,arg));}
   else error(E_NOSYMBOL);
-  putprop(ctx,funcname,
-	 (isstring(ccar(ccdr(arg))))?(ccar(ccdr(arg))):(ccar(arg)),
-	 K_FUNCTION_DOCUMENTATION);
+  // Add documentation in the form (arglist . docstring)
+  if (ccar(arg) == NIL) {
+    doc=makestring("()",2);}
+  else {
+    doc=(pointer)mkstream(ctx,K_OUT,makebuffer(256));
+    prinx(ctx,ccar(arg),doc); // arglist
+    doc=makestring((char *)doc->c.stream.buffer->c.str.chars,intval(doc->c.stream.count));}
+  if (isstring(ccar(ccdr(arg))) && ccdr(ccdr(arg)) != NIL) {
+    doc=cons(ctx,doc,ccar(ccdr(arg)));}
+  else {
+    doc=cons(ctx,doc,makestring("",0));}
+  putprop(ctx,funcname,doc,K_FUNCTION_DOCUMENTATION);
   return(funcname);}
  
 pointer DEFMACRO(ctx,arg)
 register context *ctx;
 pointer arg;
-{ pointer macname;
+{ pointer macname,doc;
 #ifdef SPEC_DEBUG
   printf("DEFMACRO:" ); hoge_print(arg);
 #endif
@@ -1123,6 +1132,18 @@ pointer arg;
   arg=ccdr(arg);
   if (issymbol(macname)) {pointer_update(macname->c.sym.spefunc,cons(ctx,MACRO,arg));}
   else error(E_NOSYMBOL);
+  // Add documentation in the form (arglist . docstring)
+  if (ccar(arg) == NIL) {
+    doc=makestring("()",2);}
+  else {
+    doc=(pointer)mkstream(ctx,K_OUT,makebuffer(256));
+    prinx(ctx,ccar(arg),doc); // arglist
+    doc=makestring((char *)doc->c.stream.buffer->c.str.chars,intval(doc->c.stream.count));}
+  if (isstring(ccar(ccdr(arg))) && ccdr(ccdr(arg)) != NIL) {
+    doc=cons(ctx,doc,ccar(ccdr(arg)));}
+  else {
+    doc=cons(ctx,doc,makestring("",0));}
+  putprop(ctx,macname,doc,K_FUNCTION_DOCUMENTATION);
   return(macname);}
 
 pointer FINDSYMBOL(ctx,n,argv)

--- a/lisp/c/specials.c
+++ b/lisp/c/specials.c
@@ -1111,8 +1111,11 @@ pointer arg;
   if (ccar(arg) == NIL) {
     doc=makestring("()",2);}
   else {
+    pointer osf=ctx->slashflag;
     doc=(pointer)mkstream(ctx,K_OUT,makebuffer(256));
+    ctx->slashflag=1;
     prinx(ctx,ccar(arg),doc); // arglist
+    ctx->slashflag=osf;
     doc=makestring((char *)doc->c.stream.buffer->c.str.chars,intval(doc->c.stream.count));}
   if (isstring(ccar(ccdr(arg))) && ccdr(ccdr(arg)) != NIL) {
     doc=cons(ctx,doc,ccar(ccdr(arg)));}
@@ -1136,8 +1139,11 @@ pointer arg;
   if (ccar(arg) == NIL) {
     doc=makestring("()",2);}
   else {
+    pointer osf=ctx->slashflag;
     doc=(pointer)mkstream(ctx,K_OUT,makebuffer(256));
+    ctx->slashflag=1;
     prinx(ctx,ccar(arg),doc); // arglist
+    ctx->slashflag=osf;
     doc=makestring((char *)doc->c.stream.buffer->c.str.chars,intval(doc->c.stream.count));}
   if (isstring(ccar(ccdr(arg))) && ccdr(ccdr(arg)) != NIL) {
     doc=cons(ctx,doc,ccar(ccdr(arg)));}

--- a/lisp/comp/comp.l
+++ b/lisp/comp/comp.l
@@ -1114,10 +1114,11 @@
        (when (> *optimize* 1)
           (putprop name cname 'user-function-entry)
           (push name *defun-list*))
-       (setq doc 
-	     (if (and (stringp (car bodies))  (cdr bodies))
-                 (cons (format nil "~a" (or arglist "()")) (pop bodies))
-                 (cons (format nil "~a" (or arglist "()")) "")))
+       (let ((arglist (if arglist (format nil "~s" arglist) "()")))
+         (setq doc
+               (if (and (stringp (car bodies))  (cdr bodies))
+                   (cons arglist (pop bodies))
+                   (cons arglist ""))))
        (send self :lambda-block name arglist bodies cname)
        (send self :add-initcode (list fun-macro cname name doc))))
  (:defmethod (methods) 
@@ -1142,10 +1143,11 @@
 	       bodies (cddr method) )
          (setq entry (send self :genlabel "M"
                            (lisp::gencname-tail myclass selector)))
-	 (setq doc 
-	       (if (and (stringp (car bodies))  (cdr bodies))
-                   (cons (format nil "~a" (or (cadr method) "()")) (pop bodies))
-                   (cons (format nil "~a" (or (cadr method) "()")) "")))
+         (let ((arglist (if (cadr method) (format nil "~s" (cadr method)) "()")))
+           (setq doc
+                 (if (and (stringp (car bodies))  (cdr bodies))
+                     (cons arglist (pop bodies))
+                     (cons arglist ""))))
 	 (send self :lambda-block selector param bodies entry)
          (send self :add-initcode
 		 (list 'defmethod myclass selector entry doc) ))

--- a/lisp/comp/comp.l
+++ b/lisp/comp/comp.l
@@ -1116,8 +1116,8 @@
           (push name *defun-list*))
        (setq doc 
 	     (if (and (stringp (car bodies))  (cdr bodies))
-		 (pop bodies)
-		 (format nil "~s" arglist)))
+                 (cons (format nil "~a" (or arglist "()")) (pop bodies))
+                 (cons (format nil "~a" (or arglist "()")) "")))
        (send self :lambda-block name arglist bodies cname)
        (send self :add-initcode (list fun-macro cname name doc))))
  (:defmethod (methods) 
@@ -1144,8 +1144,8 @@
                            (lisp::gencname-tail myclass selector)))
 	 (setq doc 
 	       (if (and (stringp (car bodies))  (cdr bodies))
-		   (pop bodies)
-		   (format nil "~s" param)))
+                   (cons (format nil "~a" (or (cadr method) "()")) (pop bodies))
+                   (cons (format nil "~a" (or (cadr method) "()")) "")))
 	 (send self :lambda-block selector param bodies entry)
          (send self :add-initcode
 		 (list 'defmethod myclass selector entry doc) ))

--- a/lisp/l/object.l
+++ b/lisp/l/object.l
@@ -27,8 +27,7 @@
 	   (push (cons (elt vars i) (slot self (class self) i)) slots))
 	(nreverse slots)))
  (:methods (&optional (pattern ""))
-    "(self class &optional (pattern \"\"))
-Returns the list of all methods callable by the object. If pattern is given, returns only methods with names that include pattern."
+    "Returns the list of all methods callable by the object. If pattern is given, returns only methods with names that include pattern."
     (mapcan #'cadr (send (class self) :all-method-names pattern)))
 ;; (:all-methods () (send (class self) :all-method-names))
  (:super () (send (class self) :super))


### PR DESCRIPTION
Keep arglist and docstring separated to avoid overwriting. https://github.com/euslisp/EusLisp/issues/303

Notes: 
- Convert arglist to strings to avoid having package delimiters as in `(lisp::slot lisp::value)` -> `"(slot value)"`
- Keep the `self` out of the arglist in method documentation
- Documentation of C defined functions are not changed (continue to be simply `docstring` or `nil`)
- Added support for non-compiled macro documentation (that was missing for some reason)