### PR TITLE
remove jessie check, because thy do not build on build.ros.org: https://discourse.ros.org/t/kinetic-builds-disabled-on-eol-platform-debian-jessie/5051

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,17 +55,7 @@ matrix:
       dist: trusty
       sudo: required
       cache: apt
-      env: DOCKER_IMAGE=debian:jessie
-    - os: linux
-      dist: trusty
-      sudo: required
-      cache: apt
       env: DOCKER_IMAGE=debian:stretch
-    - os: linux
-      dist: trusty
-      sudo: required
-      cache: apt
-      env: DOCKER_IMAGE=osrf/debian_arm64:jessie
     - os: linux
       dist: trusty
       sudo: required


### PR DESCRIPTION
because they do not build on build.ros.org: https://discourse.ros.org/t/kinetic-builds-disabled-on-eol-platform-debian-jessie/5051