### PR TITLE
[sequences.tex] add small sample of map and mapcar

### DIFF
--- a/doc/jlatex/jsequences.tex
+++ b/doc/jlatex/jsequences.tex
@@ -71,7 +71,7 @@
 \funcdesc{map}{result-type function seq \&rest more-seqs}{
 {\em function}は、{\em seq}と{\em more-seqs}のそれぞれのN番目($N=0,1,\cdots$)の要素
 からなるリストに
-対して適用され、その結果は{\em result-type}の型の列に蓄積される。}
+対して適用され、その結果は{\em result-type}の型の列に蓄積される。例えば、{\tt (map float-vector \#'(lambda (x) (* x x)) (float-vector 1 2 3))}のように書く。}
 
 \funcdesc{fill}{sequence item \&key (start 0) (end (length sequence))}{
 {\em sequence}の{\em start}番目から({\em end}$-$1)番目まで、{\em item}で満たす。}
@@ -405,7 +405,7 @@ atomやいろんな深さのリストを含んだ{\em complex-list}を、
 
 \funcdesc{mapcar}{func \&rest arg-list}{
 {\em arg-list}のそれぞれの要素に{\em func}を{\bf map}し、
-その全ての結果のリストを作る。
+その全ての結果のリストを作る。例えば、{\tt (mapcar \#'(lambda (x) (* x x)) '(1 2 3))}のように書く。
 {\bf mapcar}を使う前に、{\bf dolist}を試すこと。}
 
 \funcdesc{mapcan}{func arg-list \&rest more-arg-lists}{

--- a/doc/latex/sequences.tex
+++ b/doc/latex/sequences.tex
@@ -72,7 +72,7 @@ Note that {\em sequence} is copied even if its type equals to {\em result-type}.
 \funcdesc{map}{result-type function seq \&rest more-seqs}{
 {\em function} is applied to a list of arguments taken from {\em seq}
 and {\em more-seqs} orderly, and the result is accumulated in a sequence
-of type {\em result-type}.}
+of type {\em result-type}. For example, you can write as follows: {\tt (map float-vector \#'(lambda (x) (* x x)) (float-vector 1 2 3))}}
 
 \funcdesc{fill}{sequence item \&key (start 0) (end (length sequence))}{
 fills {\em item} from {\em start}th through ({\em end}-1)th in {\em sequence}.}
@@ -402,7 +402,7 @@ The results of application are ignored and {\em arg-list} is returned.}
 
 \funcdesc{mapcar}{func \&rest arg-list}{
 maps {\em func} to each element of {\em arg-list},
-and makes a list from all the results.
+and makes a list from all the results. For example, you can write as follows: {\tt (mapcar \#'(lambda (x) (* x x)) '(1 2 3))}.
 Before using {\bf mapcar}, try {\bf dolist}.}
 
 \funcdesc{mapcan}{func arg-list \&rest more-arg-lists}{


### PR DESCRIPTION
I added small explanations of how to use `map` and `mapcar`. 
When I've writing https://github.com/jsk-ros-pkg/jsk_robot/pull/1074, I thought it would be useful if there were samples of them.

(By the way, how to compile (j-)manual.pdf...? I'd like to check whether my PR is ok to be merged,) 