### PR TITLE
[jarith.tex, arith.tex] fix definition of tanh

### DIFF
--- a/doc/jlatex/jarith.tex
+++ b/doc/jlatex/jarith.tex
@@ -281,7 +281,7 @@ $\frac{e^{x}+e^{-x}}{2}$で表される。}
 
 \funcdesc{tanh}{x}{
 hyperbolic tangent、
-$\frac{e^{x}+e^{-x}}{e^{x}-e^{-x}}$で表される。}
+$\frac{e^{x}-e^{-x}}{e^{x}+e^{-x}}$で表される。}
 
 \funcdesc{asin}{x}{
 arc sine.}

--- a/doc/latex/arith.tex
+++ b/doc/latex/arith.tex
@@ -285,7 +285,7 @@ $\frac{e^{x}+e^{-x}}{2}$.}
 
 \funcdesc{tanh}{x}{
 hyperbolic tangent, that is,
-$\frac{e^{x}+e^{-x}}{e^{x}-e^{-x}}$.}
+$\frac{e^{x}-e^{-x}}{e^{x}+e^{-x}}$.}
 
 \funcdesc{asin}{x}{
 arc sine.}


### PR DESCRIPTION
Definition of tanh in manual.pdf and jmanual.pdf was incorrect. 
<img src="https://latex.codecogs.com/gif.latex?\tanh{=}\frac{e^{x}-e^{-x}}{e^{x}+e^{-x}}">
<img src="https://latex.codecogs.com/gif.latex?\tanh\neq\frac{e^{x}+e^{-x}}{e^{x}-e^{-x}}">

see: https://en.wikipedia.org/wiki/Hyperbolic_function#Exponential_definitions