### PR TITLE
update longdescription in documentation.l

### DIFF
--- a/lib/llib/documentation.l
+++ b/lib/llib/documentation.l
@@ -108,7 +108,7 @@
 		      (cond ((null doc)
 			     (format t "~A" (escape-string (format nil "\\metdesc{~A}{~A}{}~%" method args-str))))
 			    (*has-key*
-			     (format t "~A" (escape-string (format nil "\\longdescription{~A}{~A}{~A}~%" method args-str doc))))
+			     (format t "~A" (escape-string (format nil "\\longdescription{method}{~A}{~A}{~A}~%" method args-str doc))))
 			    (t
 			     (format t "~A" (escape-string (format nil "\\methoddesc{~A}{~A}{~A}~%" method args-str doc))))))
                      (:md
@@ -175,7 +175,7 @@
 	   (cond ((null doc)
 		  (format t "~A" (escape-string (format nil "\\fundesc{~A}{~A}~%" funcname args-str))))
 		 (*has-key*
-		  (format t "~A" (escape-string (format nil "\\longdescription{~A}{~A}{~A}~%" funcname args-str doc))))
+		  (format t "~A" (escape-string (format nil "\\longdescription{function}{~A}{~A}{~A}~%" funcname args-str doc))))
 		 (t
 		  (format t "~A" (escape-string (format nil "\\funcdesc{~A}{~A}{~A}~%" funcname args-str doc))))
 		 ))


### PR DESCRIPTION
https://github.com/euslisp/EusLisp/commit/b6a25e96c7265d3653593a1310775f9849ff7bd7#diff-95f8abe64beb6e0fc27b68349ac0cac7 in https://github.com/euslisp/EusLisp/pull/359 changed the definition of longdescription and we need to update documentation.l (which is only used in jskeus for now) too

Cc: @Affonso-Gui