### PR TITLE
Fix for readthedocs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ after_deploy:
   - git checkout -b $(git name-rev --name-only $(git rev-parse $TRAVIS_BRANCH) | sed 's@remotes/upstream/@@')
   # send doc to current repo
   - git rm -f doc/{latex,jlatex,html}/*.{pdf,ps,dvi,html,png}
-  - git add doc/{latex,jlatex}/*.{pdf,ps,dvi} doc/html/*.{html,png}
+  - git add doc/{latex,jlatex}/*.{pdf,ps,dvi,hlp} doc/html/*.{html,png}
   - git status
   - git branch
   - git commit -m "Build documents from $TRAVIS_TAG@$TRAVIS_COMMIT" doc/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## [EusLisp] [![Build Status](https://travis-ci.org/euslisp/EusLisp.png?branch=master)](https://travis-ci.org/euslisp/EusLisp)
+## [EusLisp] [![Build Status](https://travis-ci.org/euslisp/EusLisp.png?branch=master)](https://travis-ci.org/euslisp/EusLisp) [![Documentation Status](https://readthedocs.org/projects/euslisp/badge/?version=latest)](https://euslisp.readthedocs.io/en/latest/?badge=latest)
 
 EusLisp was originally developed by [Dr. Toshihiro Matsui at AIST](http://staff.aist.go.jp/t.matsui/ )
 

--- a/doc/html/conf.py
+++ b/doc/html/conf.py
@@ -27,7 +27,7 @@ sh("export CURDIR=`pwd`; cd ../jlatex/; LATEX2HTMLDIR=$CURDIR/tmp/usr/share/late
 
 # copy result to docs and _build/html
 sh("cd ../../; ln -sf doc/html docs")
-sh("cp * _build/html/; echo 'ok'")
+sh("mkdir -p _build/html; cp * _build/html/; echo 'ok'")
 
 # custom settings conf.py
 master_doc = 'index'

--- a/doc/jlatex/Makefile
+++ b/doc/jlatex/Makefile
@@ -25,7 +25,7 @@ distclean: clean
 
 html:
 	rm -f ../html/jmanual*.
-	TRANSPARENT_COLOR="#ffffff" charset="UTF-8" latex2html -dir ../html/ -transparent -local_icons -split +3 -auto_prefix -init_file ../latex/.latex2html-init -iso_language JP jmanual
+	TRANSPARENT_COLOR="#ffffff" charset="UTF-8" latex2html -dir ../html/ -transparent -local_icons -split +3 -auto_prefix -init_file ../latex/.latex2html-init -iso_language JP  -html_version="4.0,unicode" jmanual
 	(cd ../html; sed -i 's@"jmanual.css"@"manual.css"@' j*.html)
 
 

--- a/doc/jlatex/Makefile
+++ b/doc/jlatex/Makefile
@@ -27,6 +27,7 @@ html:
 	rm -f ../html/jmanual*.
 	TRANSPARENT_COLOR="#ffffff" charset="UTF-8" latex2html -dir ../html/ -transparent -local_icons -split +3 -auto_prefix -init_file ../latex/.latex2html-init -iso_language JP  -html_version="4.0,unicode" jmanual
 	(cd ../html; sed -i 's@"jmanual.css"@"manual.css"@' j*.html)
+	(cd ../html; for imgfile in jmanual-img*.png; do pngtopnm $$imgfile > /tmp/$$imgfile.pnm; pnmtopng -transparent white /tmp/$$imgfile.pnm > $$imgfile; done)
 
 
 

--- a/doc/jlatex/Makefile
+++ b/doc/jlatex/Makefile
@@ -25,9 +25,8 @@ distclean: clean
 
 html:
 	rm -f ../html/jmanual*.
-	TRANSPARENT_COLOR="#ffffff" charset="UTF-8" latex2html -dir ../html/ -transparent -local_icons -split +3 -auto_prefix -init_file ../latex/.latex2html-init -iso_language JP  -html_version="4.0,unicode" jmanual
+	TRANSPARENT_COLOR="#ffffff" charset="UTF-8" latex2html -dir ../html/ -transparent -local_icons -split +3 -auto_prefix -init_file ../latex/.latex2html-init -iso_language JP -address "This document was generated using the LaTeX2HTML translator on `date` from <a href=\"http://github.com/euslisp/EusLisp.git\">EusLisp</a> version <a href=\"http://github.com/euslisp/EusLisp/commit/`git rev-parse --verify HEAD`\">`git log -1  --oneline`</a>" -html_version="4.0,unicode" jmanual
 	(cd ../html; sed -i 's@"jmanual.css"@"manual.css"@' j*.html)
 	(cd ../html; for imgfile in jmanual-img*.png; do pngtopnm $$imgfile > /tmp/$$imgfile.pnm; pnmtopng -transparent white /tmp/$$imgfile.pnm > $$imgfile; done)
-
 
 

--- a/doc/latex/.latex2html-init
+++ b/doc/latex/.latex2html-init
@@ -1,6 +1,5 @@
 #LaTeX2HTML Version 96.1 : dot.latex2html-init
 
-$LATEX_COLOR = "\\pagecolor[rgb]{1,1,1}";
 $COLOR_HTML = 1;
 
 sub top_navigation_panel {

--- a/doc/latex/Makefile
+++ b/doc/latex/Makefile
@@ -26,3 +26,4 @@ distclean: clean
 html:
 	rm -f ../html/manual*.{old,html,png,pl} ../html/manual-images.*
 	TRANSPARENT_COLOR="#ffffff" latex2html -dir ../html/ -transparent -local_icons -split +3 -auto_prefix -iso_language JP -html_version="4.0,unicode" manual
+	(cd ../html; for imgfile in manual-img*.png; do pngtopnm $$imgfile > /tmp/$$imgfile.pnm; pnmtopng -transparent white /tmp/$$imgfile.pnm > $$imgfile; done)

--- a/doc/latex/Makefile
+++ b/doc/latex/Makefile
@@ -25,4 +25,4 @@ distclean: clean
 
 html:
 	rm -f ../html/manual*.{old,html,png,pl} ../html/manual-images.*
-	TRANSPARENT_COLOR="#ffffff" latex2html -dir ../html/ -transparent -local_icons -split +3 -auto_prefix -iso_language JP manual
+	TRANSPARENT_COLOR="#ffffff" latex2html -dir ../html/ -transparent -local_icons -split +3 -auto_prefix -iso_language JP -html_version="4.0,unicode" manual

--- a/doc/latex/Makefile
+++ b/doc/latex/Makefile
@@ -25,5 +25,5 @@ distclean: clean
 
 html:
 	rm -f ../html/manual*.{old,html,png,pl} ../html/manual-images.*
-	TRANSPARENT_COLOR="#ffffff" latex2html -dir ../html/ -transparent -local_icons -split +3 -auto_prefix -iso_language JP -html_version="4.0,unicode" manual
+	TRANSPARENT_COLOR="#ffffff" latex2html -dir ../html/ -transparent -local_icons -split +3 -auto_prefix -iso_language JP -address "This document was generated using the LaTeX2HTML translator on `date` from <a href=\"http://github.com/euslisp/EusLisp.git\">EusLisp</a> version <a href=\"http://github.com/euslisp/EusLisp/commit/`git rev-parse --verify HEAD`\">`git log -1  --oneline`</a>" -html_version="4.0,unicode" manual
 	(cd ../html; for imgfile in manual-img*.png; do pngtopnm $$imgfile > /tmp/$$imgfile.pnm; pnmtopng -transparent white /tmp/$$imgfile.pnm > $$imgfile; done)


### PR DESCRIPTION
see https://euslisp.readthedocs.io/en/fix-rtd

- add the current time stop to the footer
- manually set transparent to the images
- $LATEX_COLOR = "\\pagecolor[rgb]{1,1,1}"  cause trouble on image conversion
- set utf-8 for latex2html
- need to make _build/html before copy html to the directory