### PR TITLE
make osx build stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ install:
 script:
   - echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then docker run --rm -i -v $HOME:$HOME -e "TRAVIS_OS_NAME=$TRAVIS_OS_NAME" -e "CI_SOURCE_PATH=$CI_SOURCE_PATH" -e "HOME=$HOME" -e "MAKEFLAGS=$MAKEFLAGS" -e "DOCKER_IMAGE=$DOCKER_IMAGE" -t $DOCKER_IMAGE sh -c "cd $CI_SOURCE_PATH; ./.travis.sh"; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx"   ]; then  source ./.travis.sh; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx"   ]; then ./.travis.sh; fi
 after_failure:
   - echo "failure"
 after_success:


### PR DESCRIPTION
Curent osx build fails 20-50% of chance....

- use ./ instead of source

c.f.: https://api.travis-ci.org/v3/job/544021875/log.txt

not sure why but
```
 source ./.travis.sh
``` 
is unstable and 
```
 ./.travis.sh
```
seems ok. `source ./.travis.sh` run the script within `zsh` and `./.travis.sh` uses `#!/bin/bash` to run the script.