### PR TITLE
Allow to return values from dolist, dotimes and do-symbols

### DIFF
--- a/lisp/l/common.l
+++ b/lisp/l/common.l
@@ -151,7 +151,7 @@
 	(while (< ,(car vars) ,endvar)
 	       ,@forms
 	       (setq ,(car vars) (1+ ,(car vars))))
-	,(caddr vars)))) 
+	,@(cddr vars))))
 
 (defmacro dolist (vars &rest forms)
    (let ((lists (gensym "DOLIST")) (decl (car forms)))
@@ -163,7 +163,7 @@
 	(while ,lists
 	   (setq ,(car vars) (pop ,lists))
 	   ,@forms)
-	,(caddr vars)))) 
+	,@(cddr vars))))
 
 (defmacro do-symbols (vars &rest forms)
    (let* ((symbols (gensym "DOSYM"))
@@ -183,7 +183,7 @@
 	   (setq ,v (elt ,svec ,i))
 	   (inc ,i)
 	   (when (symbolp ,v) . ,forms))
-	,(caddr vars))))
+	,@(cddr vars))))
 
 (defmacro do-external-symbols (vars &rest forms)
    (let* ((symbols (gensym "DOEXTSYM"))
@@ -203,7 +203,7 @@
 	   (setq ,v (elt ,svec ,i))
 	   (inc ,i)
 	   (when (symbolp ,v) . ,forms))
-	,(caddr vars))))
+	,@(cddr vars))))
 
 (defmacro do-all-symbols (var &rest forms)
    (let ((apackage (gensym "DOALLSYM")))


### PR DESCRIPTION
Partially solves https://github.com/euslisp/EusLisp/issues/241

It is not as complete as the gist solution on the discussion, but is done with minimal changes and is sufficient for cases when the return value is omitted.
```lisp
(dolist (i (list 1 2 3))
  (print i)
  (return t))
1
t
```

Remains the same (= different from cl) when the return value is explicitly given:
```lisp
(dolist (i (list 1 2 3) 10)
  (print i)
  (return t))
1
10
```