### PR TITLE
fix tex files in jlatex to make latex.py happy, {\bfx } -> \bfx{ }, fix wrong arguments in funcdesc/methoddoc

### DIFF
--- a/doc/jlatex/jgenerals.tex
+++ b/doc/jlatex/jgenerals.tex
@@ -384,7 +384,7 @@ Euslispは、数を表現するクラスを持っていないので、数の型�
 あるいは{\bf :fixnum}が整数型を表現するために使用され、
 {\bf :float}あるいは{\bf float}が実数型を表現するために使用される。
 {\bf make-array}の{\em element-type}引数においては、文字列を作るために
-{\bf :character}, {\bf character}, {\bf :byte}や{\bfx byte}を
+{\bf :character}, {\bf character}, {\bf :byte}や\bfx{byte}を
 認識する。
 {\bf defcstruct}, {\bf sys:peek}や{\bf sys:poke}のような低レベルの関数も、
 バイト毎にアクセスするために

--- a/doc/jlatex/jgeometry.tex
+++ b/doc/jlatex/jgeometry.tex
@@ -1,7 +1,7 @@
 \section{\label{Geometry}幾何学モデリング}
 \markright{\arabic{section}. 幾何学モデリング}
 
-Euslispは、３次元の幾何学モデルの内部表現として{\emx Brep}（境界表現）を採用している。
+Euslispは、３次元の幾何学モデルの内部表現として\emx{Brep}（境界表現）を採用している。
 Brep内の要素は{\bf edge, plane, polygon, face, hole,}や{\bf body}クラスによって
 表現される。
 基本bodyの作成関数とbodyの合成関数は、これらのクラスの新しい
@@ -746,8 +746,8 @@ x,y,z軸の方向に大きさが{\em xsize},{\em ysize},{\em zsize}である，�
 もし，頂点のリストなら，順番を慎重にしなさい。
 %%% change 2004.12.14 \verb+ (make-cone \#f(0 0 10) (list \#f(10 0 0) \#f(0 10 0) \#f(-10 0 0)
 %%% change 2004.12.14 \#f(0 -10 0)))+ は，正方形の底面を持つ四角錐を作る。}
-\verb~ (make-cone \#f(0 0 10) (list \#f(10 0 0) \#f(0 10 0) \#f(-10 0 0)
-\#f(0 -10 0)))~ は，正方形の底面を持つ四角錐を作る。}
+\verb~ (make-cone \#f(0 0 10) (list \#f(10 0 0) \#f(0 10 0) \#f(-10 0 0) \#f(0 -10 0)))~
+は，正方形の底面を持つ四角錐を作る。}
 
 \funcdesc{make-solid-of-revolution}{points \&key (segments 16) name color}{
 {\em points}は，z軸まわりの時計方向に回転される。

--- a/doc/jlatex/jintro.tex
+++ b/doc/jlatex/jintro.tex
@@ -233,7 +233,7 @@ Euslispのオーガナイズドセッションが開かれた。
 その他は、付属ライブラリ・デモプログラム・ユーザーからの寄贈品である。
 
 \begin{table}
-\caption{\label{Directories}{\tt *eusdir*}のディレクトリ}
+\caption{{\tt *eusdir*}のディレクトリ\label{Directories}}
 \begin{center}
 {\footnotesize
 \begin{tabular}{|l | l|}\hline 

--- a/doc/jlatex/jmthread.tex
+++ b/doc/jlatex/jmthread.tex
@@ -393,8 +393,8 @@ mutex-lockとmutex-unlockは、組みで使用されなければならない。
 {\em sem}に信号が来るまで待つ。}
 
 \classdesc{sys:barrier-synch}{propertied-object}{
-threads n-threads count barrier-cond threads-lock count-lock}
-{同期障壁のための構造を表現する。
+threads n-threads count barrier-cond threads-lock count-lock}{
+同期障壁のための構造を表現する。
 同期を待っているスレッドは、{\em thread-lock}によって
 相互に排除される{\em thread}に置かれる。
 {\bf barrier-synch}オブジェクトが生成されたとき、

--- a/doc/jlatex/jobjects.tex
+++ b/doc/jlatex/jobjects.tex
@@ -297,8 +297,8 @@ symbolが{\tt indicator}として用いられたとき、内部パッケージ�
 {\bf metaclass}は、複数クラスを定義する。独自のクラス変数を持つ複数クラスは、
 それらのスーパークラスとして{\bf metaclass}を定義しなければならない。}
 
-\methoddesc{:new}{}
-{このクラスのインスタンスを生成し、全てのスロットをNILにした後、
+\methoddesc{:new}{}{
+このクラスのインスタンスを生成し、全てのスロットをNILにした後、
 それを返す。}
 
 \methoddesc{:super}{}{

--- a/doc/jlatex/jsymbols.tex
+++ b/doc/jlatex/jsymbols.tex
@@ -169,7 +169,7 @@ Common Lispでパッケージシステムが生まれた。
 symbolをexportあるいはimportするとき、あらゆるパッケージ内の
 全てのsymbolが独自の
 print-nameを持つ必要があるため、symbol名の重複を発見することができる。
-{\bfx shadow}は、パッケージからsymbolを仮想的に削除することにより、
+\bfx{shadow}は、パッケージからsymbolを仮想的に削除することにより、
 存在するsymbolと同じ名前のsymbolを作成することができる。
 
 Euslispは次の8つのパッケージを定義する。


### PR DESCRIPTION
same fix as 5f96c102eccb8cc0621d4d31261499a0167ae0f3