### PR TITLE
Fix variable capture in unittest.l

### DIFF
--- a/lib/llib/unittest.l
+++ b/lib/llib/unittest.l
@@ -232,19 +232,17 @@
            (trace ,name))))
 
     (defmacro assert (pred &optional (message "") &rest args)
-      (let
-        ((ret (gensym)))
-       `(let* (failure (ret ,pred))
-	  ;; lisp::step could not work with macros..
-	  ;;     (if (and (listp ',pred) (functionp (car ',pred)))
-	  ;;	 (setq ret (lisp::step ,pred))
-	  ;;       (setq ret ,pred))
-	  ;;
-	  (if (not ret)
-	      ;; escape <> for xml
-	      (send *unit-test* :increment-failure ',pred (format nil ,message ,@args)
-		    (escape-xml-string (subseq (send *error-output* :buffer) 0 (or (position 0 (send *error-output* :buffer)) (length (send *error-output* :buffer)))))))
-	  )))
+      `(let (failure (ret ,pred))
+         ;; lisp::step could not work with macros..
+         ;;     (if (and (listp ',pred) (functionp (car ',pred)))
+         ;;	 (setq ret (lisp::step ,pred))
+         ;;       (setq ret ,pred))
+         ;;
+         (if (not ret)
+             ;; escape <> for xml
+             (send *unit-test* :increment-failure ',pred (format nil ,message ,@args)
+                   (escape-xml-string (subseq (send *error-output* :buffer) 0 (or (position 0 (send *error-output* :buffer)) (length (send *error-output* :buffer)))))))
+         ))
 
 
     t))


### PR DESCRIPTION
Not really sure why I have missed this, but in `unittest.l` we have (i) unused gensym variable and (ii) variable name capture in the `assert` redefine.

https://github.com/euslisp/EusLisp/blob/9dc7c5f9df0019f97f4989de1d9d4be811960658/lib/llib/unittest.l#L234-L247

Fixing those two problems. Can be tested with
```lisp
(deftest test-name-capture (let ((failure t)) (assert failure)))  ;; FAILURE
```