### PR TITLE
Safely exit format on mismatch argument

### DIFF
--- a/lisp/c/lispio.c
+++ b/lisp/c/lispio.c
@@ -491,10 +491,11 @@ pointer argv[];
 	if (islower(cch)) cch=toupper(cch);}
       switch(cch) {
 	case 'A':	/*Ascii*/
+	  a=nextfarg();
 	  osf=ctx->slashflag;
 	  ctx->slashflag=1;
 	  written_count[thr_self()]=0;
-	  prinx(ctx,(pointer)nextfarg(),dest);
+	  prinx(ctx,a,dest);
 	  while (param[0]>written_count[thr_self()]) writech(dest,' ');
 	  ctx->slashflag=osf;
 	  break;


### PR DESCRIPTION
Fix the following bug, when `format` is interrupted with `mismatch argument` error:
```lisp
(format t "~S" (list "abc" 10))
;; ("abc" 10)

(format t "~A")
Call Stack (max depth: 20):
  0: at (format t ~A)
  1: at #<compiled-code #X64c1e28>
eus 0 error: mismatch argument in (format t ~A)

(format t "~S" (list "abc" 10))
;; (abc 10) < correct is ("abc" 10) , with quotes
```

This happens because the argument check included in `nextfarg` is done after the `slashflag` is altered, leaving it stuck at `1` after the error occurs.