### PR TITLE
[jmatrix.tex]add v= to manual

### DIFF
--- a/doc/jlatex/jmatrix.tex
+++ b/doc/jlatex/jmatrix.tex
@@ -35,6 +35,10 @@ float-vectorは、どんなサイズでも良い。
 \funcdesc{v.*}{fltvec1 fltvec2 fltvec3}{
 スカラー3重積を計算する。{\tt (v.* A B C)=(V. A (V* B C))=(V. (V* A B) C)}}
 
+\funcdesc{v$=$}{fltvec1 fltvec2}{
+  もし、{\em fltvec1}の要素が{\em fltvec2}の対応する要素とすべて等しいとき、
+Tを返す。}
+
 \funcdesc{v$<$}{fltvec1 fltvec2}{
 もし、{\em fltvec1}の要素が{\em fltvec2}の対応する要素よりすべて小さいとき、
 Tを返す。}


### PR DESCRIPTION
関数```v=```がjmanualに含まれていなかったため、追加しました。