### PR TITLE
Print E_USER message on default error handler

### DIFF
--- a/lisp/c/eus.c
+++ b/lisp/c/eus.c
@@ -390,7 +390,7 @@ va_dcl
 	prinx(ctx,msg,ERROUT); flushstream(ERROUT); break;
     }
   if( ec == E_USER ) {
-      fprintf( stderr,"%p",msg ); flushstream(ERROUT); }
+    fprintf( stderr,"%s",(char*)msg ); flushstream(ERROUT); }
   else if (ispointer(msg)) {prinx(ctx,msg,ERROUT); flushstream(ERROUT); }
   if (ctx->callfp) {
     fprintf(stderr," in ");


### PR DESCRIPTION
Print the error message instead of its pointer in the default error handler.
Solves: https://github.com/jsk-ros-pkg/jsk_roseus/issues/626