### PR TITLE
[WIP] Avoid infinite loop when hash-table has no empty members

### DIFF
--- a/lisp/l/hashtab.l
+++ b/lisp/l/hashtab.l
@@ -28,7 +28,9 @@
 (defmethod hash-table
  (:size () size)
  (:find (s)
-    (let* ((hash (abs (mod (funcall hash-function s) size))) (entry) (empty-pos))
+    (let* ((hash (abs (mod (funcall hash-function s) size)))
+           (first-hash hash)
+           (entry) (empty-pos))
       (while t
 	(setq entry (svref key hash))
 	(if (funcall test-function entry s) (return-from :find hash))
@@ -37,7 +39,11 @@
 	      (return-from :find (+ empty-pos size)))
 	(when (eq entry deleted)
 	      (if (null empty-pos) (setq empty-pos hash)))
-	(if (>= (inc hash) size) (setq hash 0)))
+	(if (>= (inc hash) size) (setq hash 0))
+	(when (eq hash first-hash)  ;; looped through all hash elements
+          (if empty-pos
+              (return-from :find (+ empty-pos size))
+              (error "hash-table is full"))))
       nil))
  (:get (s)
     (let ((entry (send self :find s)))


### PR DESCRIPTION
***Problem:***
Infinite loops when hash-table has no empty members

***Code to reproduce:***
```lisp
(defvar ht (make-hash-table))
(dotimes (i (send ht :size))
  (send ht :enter i "foo")
  (send ht :delete i))
(send ht :enter 0 "foo")
;; infinite loop
```

***Why it happens:***
- On the first loop the hash-table gets full with `del` symbols
- The `:find` method loops until it finds an empty member, which in this case does not exist

***Solution:***
After all elements are iterated in the `:find` method, return the first available slot (del symbol). If there are no available slots, raise an error reporting that the hash-table is full.


Thanks to @ikeshou for finding the bug!