### PR TITLE
geo/intersection.c: fix intersection3 (may be optimization problem)

### DIFF
--- a/lisp/geo/intersection.c
+++ b/lisp/geo/intersection.c
@@ -91,7 +91,7 @@ register pointer argv[];
   eusfloat_t cz,u,v;
   eusfloat_t *p1, v1[3], *p2, v2[3], p2p1[3];
   eusfloat_t cross[3], cross2;
-  numunion nu;
+  volatile numunion nu;
 
   ckarg2(4,5);
   if (!isfltvector(argv[0])) error(E_FLOATVECTOR,NULL);


### PR DESCRIPTION
Why does the test pass on arm64 ( https://github.com/euslisp/jskeus/pull/561 / https://travis-ci.org/github/euslisp/jskeus/builds/680614717 )

This is likely an optimization problem.
https://github.com/euslisp/EusLisp/blob/master/lisp/geo/intersection.c#L118


x86_64 (it's correct)
~~~
(setq l0 (make-line #f(-120.0 -30.0 0.0) #f(15.0 0.0 0.0)))
(setq l1 (make-line #f(-15.0 120.0 0.0)  #f(-15.0 0.0 0.0)))

(geo::line-intersection3 (l0 . pvert) (l0 . nvert) (l1 . pvert) (l1 . nvert) 0.00001) ;; -> (0.777778 1.05556)
(geo::line-intersection3 (l1 . pvert) (l1 . nvert) (l0 . pvert) (l0 . nvert) 0.00001) ;; -> (1.05556 0.777778)
~~~


arm64 (return same value)
~~~
(setq l0 (make-line #f(-120.0 -30.0 0.0) #f(15.0 0.0 0.0)))
(setq l1 (make-line #f(-15.0 120.0 0.0)  #f(-15.0 0.0 0.0)))

(geo::line-intersection3 (l0 . pvert) (l0 . nvert) (l1 . pvert) (l1 . nvert) 0.00001) ;; -> (1.05556 1.05556)
(geo::line-intersection3 (l1 . pvert) (l1 . nvert) (l0 . pvert) (l0 . nvert) 0.00001) ;; -> (0.777778 0.777778)
~~~