### PR TITLE
Close help file after reading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
     # hppa
     # hurd-i386
     - env: QEMU=i386 DOCKER_IMAGE=i386/debian:unstable # i386
+    - env: QEMU=i386 DOCKER_IMAGE=i386/debian:buster # i386
     # ia64
     # m68k
     - env: QEMU=mips64el DOCKER_IMAGE=loongnix/debian:buster # mips64el
@@ -35,6 +36,8 @@ matrix:
     # sh4
     # sparc64
     - os: osx
+  allow_failures:
+    - env: QEMU=i386 DOCKER_IMAGE=i386/debian:unstable # i386 fails due to invalid signature https://github.com/debuerreotype/docker-debian-artifacts/issues/101
 env:
   global:
     - MAKEFLAGS='-j4'

--- a/lisp/l/eushelp.l
+++ b/lisp/l/eushelp.l
@@ -170,7 +170,8 @@
           (if (eq type *type-METHOD*)
               (sethash name (help-item-mhash (gethash class *help-hash*)) (instance help-item :init type fname seek args class))
 	      (sethash name *help-hash* (instance help-item :init type fname seek args)))
-	  )))
+	  )
+    (close fp)))
 
 (in-package "USER")
 (use-package "HELP")


### PR DESCRIPTION
- not sure why, but currently i386/debian:unstable could not run 'apt upate', use 'buster' https://github.com/debuerreotype/docker-debian-artifacts/issues/69
- Close help file after reading

Closes  #446