### PR TITLE
[Needs discussion] Fix assoc :key behavior

### DIFF
--- a/lisp/c/lists.c
+++ b/lisp/c/lists.c
@@ -360,8 +360,8 @@ register pointer argv[];
   while (islist(alist)) {
     target=ccar(alist);
     if (islist(target)) {	/*ignore non-pair elements*/
-      if (key==NIL) temp=ccar(target);
-      else temp=call1(ctx,key,target);
+      temp=ccar(target);
+      if (key!=NIL) temp=call1(ctx,key,temp);
       if (testnot!=NIL) compare=(call2(ctx,testnot,item,temp)==NIL);
       else if (test==NIL || test==QEQ) compare=(item==temp);
       else if (test==QEQUAL) compare=(equal(item,temp)==T);


### PR DESCRIPTION
EusLisp have the non-standard behavior of applying assoc's :key argument on each form, instead of on each of its car values:
```
eus$ (assoc 3 '((1 . "one") (2 . "two") (3 . "three")) :key #'print)
(1 . "one")
(2 . "two")
(3 . "three")
;; nil

sbcl$ (assoc 3 '((1 . "one") (2 . "two") (3 . "three")) :key #'print)
1 
2 
3 
;; (3 . "three")
```

This PR implements the standard :key argument behavior in EusLisp as well. 
```
eus$ (assoc 3 '((1 . "one") (2 . "two") (3 . "three")) :key #'print)
1
2
3
;; (3 . "three")
```

This is **not backward compatible**, but I am opening it because Inaba-sensei has pointed the EusLisp behavior as a bug (https://github.com/euslisp/EusLisp/issues/436), granted that 'nobody is using this in code' and asked for a PR.
@inabajsk 