### PR TITLE
fix sphinx version for circleci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
       - run:
           name: Install Sphinx
           command: |
-            pip3 install --user sphinx==3.3.1 jinja2==2.11.3 sphinx_rtd_theme==0.5.0 MarkupSafe==1.1.1
+            pip3 install --user sphinx==3.3.1 jinja2==2.11.3 sphinx_rtd_theme==0.5.0 MarkupSafe==1.1.1 packaging==20.8
       - run:
           name: Build reStructuredText(reST)
           command: cd /tmp/rst && ~/.local/bin/sphinx-build . html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,8 +115,8 @@ jobs:
       - run:
           name: Install Sphinx
           command: |
-            pip3 install --user sphinx
-            pip3 install --user sphinx_rtd_theme
+            pip3 install --user sphinx==3.3.1
+            pip3 install --user sphinx_rtd_theme==0.5.0
       - run:
           name: Build reStructuredText(reST)
           command: cd /tmp/rst && ~/.local/bin/sphinx-build . html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,8 +115,7 @@ jobs:
       - run:
           name: Install Sphinx
           command: |
-            pip3 install --user sphinx==3.3.1 jinja2==2.11.3
-            pip3 install --user sphinx_rtd_theme==0.5.0
+            pip3 install --user sphinx==3.3.1 jinja2==2.11.3 sphinx_rtd_theme==0.5.0 MarkupSafe==1.1.1
       - run:
           name: Build reStructuredText(reST)
           command: cd /tmp/rst && ~/.local/bin/sphinx-build . html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
       - run:
           name: Install Sphinx
           command: |
-            pip3 install --user sphinx==3.3.1
+            pip3 install --user sphinx==3.3.1 jinja2==2.11.3
             pip3 install --user sphinx_rtd_theme==0.5.0
       - run:
           name: Build reStructuredText(reST)


### PR DESCRIPTION
circleci fails to build rst.
this is because `sphinx` drop `python3.5`, but `python3.5` installs latest `sphinx=4.1.2`, which have variable annotation in their code :(
I fix sphinx version for circleci.

https://app.circleci.com/pipelines/github/euslisp/EusLisp/299/workflows/4178251d-b02f-4ab4-bb99-7959d56ec6a2/jobs/1363/tests