### PR TITLE
apply patches in dfsg

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -82,6 +82,8 @@ if [ "$QEMU" != "" ]; then
     export GIT_SSL_NO_VERIFY=1
     git clone http://salsa.debian.org/science-team/euslisp /tmp/euslisp-dfsg
     for file in $(cat /tmp/euslisp-dfsg/debian/patches/series); do
+        # skip patches already applied by https://github.com/euslisp/EusLisp/pull/482
+        [[ $file =~ use-rtld-global-loadelf.patch ]] && continue;
         # skip patch already applied by https://github.com/euslisp/EusLisp/pull/441
         if [[ $file =~  fix-for-reprotest.patch ]]; then
             filterdiff -p1 -x 'lisp/image/jpeg/makefile' -x 'lisp/comp/comp.l' < /tmp/euslisp-dfsg/debian/patches/$file > /tmp/euslisp-dfsg/debian/patches/$file-fix

--- a/.travis.sh
+++ b/.travis.sh
@@ -83,7 +83,7 @@ if [ "$QEMU" != "" ]; then
     git clone http://salsa.debian.org/science-team/euslisp /tmp/euslisp-dfsg
     for file in $(cat /tmp/euslisp-dfsg/debian/patches/series); do
         # skip patches already applied by https://github.com/euslisp/EusLisp/pull/482
-        [[ $file =~ use-rtld-global-loadelf.patch ]] && continue;
+        [[ $file =~ use-rtld-global-loadelf.patch|fix-arm-ldflags.patch|fix-library-not-linked-against-libc.patch ]] && continue;
         # skip patch already applied by https://github.com/euslisp/EusLisp/pull/441
         if [[ $file =~  fix-for-reprotest.patch ]]; then
             filterdiff -p1 -x 'lisp/image/jpeg/makefile' -x 'lisp/comp/comp.l' < /tmp/euslisp-dfsg/debian/patches/$file > /tmp/euslisp-dfsg/debian/patches/$file-fix

--- a/.travis.sh
+++ b/.travis.sh
@@ -83,7 +83,7 @@ if [ "$QEMU" != "" ]; then
     git clone http://salsa.debian.org/science-team/euslisp /tmp/euslisp-dfsg
     for file in $(cat /tmp/euslisp-dfsg/debian/patches/series); do
         # skip patches already applied by https://github.com/euslisp/EusLisp/pull/482
-        [[ $file =~ use-rtld-global-loadelf.patch|fix-arm-ldflags.patch|fix-library-not-linked-against-libc.patch ]] && continue;
+        [[ $file =~ use-rtld-global-loadelf.patch|fix-arm-ldflags.patch|fix-library-not-linked-against-libc.patch|fix-manpage-has-bad-whatis-entry-on-man-pages.patch ]] && continue;
         # skip patch already applied by https://github.com/euslisp/EusLisp/pull/441
         if [[ $file =~  fix-for-reprotest.patch ]]; then
             filterdiff -p1 -x 'lisp/image/jpeg/makefile' -x 'lisp/comp/comp.l' < /tmp/euslisp-dfsg/debian/patches/$file > /tmp/euslisp-dfsg/debian/patches/$file-fix

--- a/doc/man/eus.1
+++ b/doc/man/eus.1
@@ -1,6 +1,6 @@
 .TH eus 1 "Apr/20/1989"
 .SH NAME
-eus eusx euscomp eusxview eusview \- EusLisp
+eus \- EusLisp
 .SH SYNOPSIS
 .nf
 eus [start-up-files]

--- a/lisp/Makefile.Linux
+++ b/lisp/Makefile.Linux
@@ -74,7 +74,7 @@ CFLAGS:= $(CFLAGS) $(CPPFLAGS) $(WFLAGS) -D$(MACHINE) -DLinux -D_REENTRANT -DVER
 
 # machine specific CFLAGS
 ifneq ($(shell gcc -dumpmachine | egrep "^(arm|aarch)"),)
-  ADD_LDFLAGS=-Wl,-z,execstack
+  ADD_LDFLAGS+=-Wl,-z,execstack
   CFLAGS+=-DARM -fPIC
   ARCH=LinuxARM
 endif

--- a/lisp/Makefile.Linux64
+++ b/lisp/Makefile.Linux64
@@ -67,7 +67,7 @@ CC=gcc
 # On Solaris, XLIB and EUSLIB are combined together into lib/libeusx.so.
 
 # Linux
-RAWLIB=-ldl -lm -lpthread
+RAWLIB=-ldl -lm -lpthread -lc
 XLIB= -L/usr/X11R6/lib -lX11
 
 # specify directories where euslisp's libraries are located.

--- a/lisp/Makefile.LinuxARM
+++ b/lisp/Makefile.LinuxARM
@@ -92,7 +92,7 @@ LD=gcc
 # On Solaris, XLIB and EUSLIB are combined together into lib/libeusx.so.
 
 # Linux
-RAWLIB=-ldl -lm -lpthread
+RAWLIB=-ldl -lm -lpthread -lc
 XLIB= -L/usr/X11R6/lib -lX11
 
 # specify directories where euslisp's libraries are located.

--- a/lisp/c/loadelf.c
+++ b/lisp/c/loadelf.c
@@ -160,7 +160,7 @@ pointer initnames;
   void *dlhandle;
   char namebuf[256];
 
-  dlhandle=dlopen(0,RTLD_LAZY);
+  dlhandle=dlopen(0,RTLD_LAZY|RTLD_GLOBAL);
   if (dlhandle==NULL) { 
     fprintf(stderr, "cannot dlopen self\n"); exit(2);}
   module_count=0;
@@ -386,7 +386,7 @@ pointer *argv;
     else entry=(char *)get_string(argv[1]);}
   else entry=NULL;
 
-  dlhandle=(eusinteger_t)dlopen(binfn, RTLD_LAZY);/* ???? */
+  dlhandle=(eusinteger_t)dlopen(binfn, RTLD_LAZY|RTLD_GLOBAL);/* ???? */
   if (dlhandle == 0) {
     fprintf(stderr,"BINLOAD cannot dlopen: %s\n", dlerror());
     return(NIL);}


### PR DESCRIPTION
apply patches in https://salsa.debian.org/science-team/euslisp/-/tree/master/debian/patches

aadb1458 (Kei Okada, 64 seconds ago)
    Fix manpage-has-bad-whatis-entry-on-man-pages

    apply fix-manpage-has-bad-whatis-entry-on-man-pages.patch

    |Description: Fix manpage-has-bad-whatis-entry-on-man-pages
    | Use hyphens to split words in a command to fix
    | manpage-has-bad-whatis-entry-on-man-pages
    | .
    | euslisp (9.26-1) unstable; urgency=low
    | .
    |   * Initial debian release (Closes: Bug#942317).
    |Author: Kei Okada <kei.okada@gmail.com>

15f65551 (Kei Okada, 12 minutes ago)
    Fix library-not-linked-against-libc

    apply euslisp-dfsg/debian/patches/fix-library-not-linked-against-libc.patch

    |Description: Fix library-not-linked-against-libc
    | Fix library-not-linked-against-libc by adding -lc for all Linux
    configuration
    | .
    | euslisp (9.26-1) unstable; urgency=low
    | .
    |   * Initial debian release (Closes: Bug#942317).
    |Author: Kei Okada <kei.okada@gmail.com>

b28898b4 (Kei Okada, 50 minutes ago)
    fix ADD_LIBRARIES in Makefile.Linux

    apply euslisp-dfsg/debian/patches/fix-arm-ldflags.patch

    |Description: fix ADD_LIBRARIES in Makefile.Linux
    | arm compile requres -Wl,--no-as-needed but it
    | was overrided by ADD_LDFLAGS
    | .
    | euslisp (9.27-1) unstable; urgency=high
    | .
    |   * Initial debian release (Closes: Bug#942317).
    |Author: Kei Okada <kei.okada@gmail.com>

d62d0137 (Kei Okada, 55 minutes ago)
    Use RTLD_GLOBAL so that other dynamic libary can find library symbols.

    apply euslisp-dfsg/debian/patches/use-rtld-global-loadelf.patch

    |  For example, this fix enable compiled lisp file to find symbol defined
    in libeusgeo.so
    |  $ cat intersection3-test.l
    |  (eval-when (load) (geo::line-intersection3 #f(0 0 -1) #f(0 0 1) #f(0 -1
    0) #f(0 1 0) 0.001))
    |  $ EUSDIR=/tmp/euslisp/lisp ./Linux64/bin/eusg '(progn (compile-file
    intersection3-test.l :o intersection3-test.o) (load
    intersection3-test.so)(print *user*)(unix::exit))'
    |
    |  c.f.) https://github.com/android/ndk/issues/201Index:
    euslisp/lisp/c/loadelf.c
    | .
    | euslisp (9.27-3) unstable; urgency=medium
    | .
    |
    |Author: Kei Okada <kei.okada@gmail.com>
    |