### PR TITLE
Fix GihtubAction for aarch64 bionic/focal

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -29,8 +29,10 @@ jobs:
           - DOCKER_IMAGE: osrf/ubuntu_armhf:xenial
           - DOCKER_IMAGE: osrf/ubuntu_arm64:trusty
           - DOCKER_IMAGE: osrf/ubuntu_arm64:xenial
-          - DOCKER_IMAGE: osrf/ubuntu_arm64:bionic
-          - DOCKER_IMAGE: osrf/ubuntu_arm64:focal
+          - QEMU: aarach64
+            DOCKER_IMAGE: arm64v8/ubuntu:bionic
+          - QEMU: aarach64
+            DOCKER_IMAGE: arm64v8/ubuntu:focal
           - DOCKER_IMAGE: osrf/debian_arm64:stretch
           - DOCKER_IMAGE: amd64/debian:unstable
             #


### PR DESCRIPTION
use arm64v8/ubuntu instead of osrf/ubuntu_arm64 for both bionic/focal