### PR TITLE
Don't decide which packages to load based on full program path in eusstart

### DIFF
--- a/lisp/l/eusstart.l
+++ b/lisp/l/eusstart.l
@@ -349,7 +349,7 @@
                   gc alloc runtime))
 	(setf (symbol-function 'exit) (symbol-function 'unix::exit))    
 ;;
-;(when (substringp "P" (string-upcase *program-name*))
+;(when (substringp "P" (string-upcase (pathname-name *program-name*)))
 	(in-package "SYSTEM")
 	(system::exec-module-init "par" "l/par.l")
 ;;
@@ -368,9 +368,10 @@
 ;; load geometric package
 ;;
 
-(when (or (substringp "G" (string-upcase *program-name*))
-	  (substringp "X" (string-upcase *program-name*))
-	  (substringp "COMP" (string-upcase *program-name*)))
+(when (let ((*program-name* (string-upcase (pathname-name *program-name*))))
+        (or (substringp "G" *program-name*)
+            (substringp "X" *program-name*)
+            (substringp "COMP" *program-name*)))
 ;;	(format t "Loading geometry modules.~%")
 	(sys:alloc 80000)
 	(sys:alloc 50000)


### PR DESCRIPTION
For years I have wondered why starting euslisp with gdb was not entirely consistent with the results without gdb.
It turns out that gdb uses the absolute path of the program. Since this typically includes an "X" in the `Linux64` directory, the geo modules are loaded (notice the additional modules below).

```
$ eus
configuring by "/opt/ros/melodic/share/euslisp/jskeus/eus//lib/eusrt.l"
;; readmacro ;; object ;; packsym ;; common ;; constants ;; stream ;; string ;; loader ;; pprint 
;; process ;; hashtab ;; array ;; mathtran ;; eusdebug ;; eusforeign ;; extnum ;; coordinates 
;; tty ;; history ;; toplevel ;; trans ;; comp ;; builtins ;; par ;; helpsub ;; eushelp ;; fstringdouble 
EusLisp 9.29() for Linux64 created on ip-10-0-1-68(Tue Mar 1 05:47:01 PST 2022)
1.eus$ *program-name*
"eus"
```

```
$ gdb eus
GNU gdb (Ubuntu 8.1.1-0ubuntu1) 8.1.1
Copyright (C) 2018 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from eus...(no debugging symbols found)...done.
(gdb) run
Starting program: /opt/ros/melodic/share/euslisp/jskeus/eus/Linux64/bin/eus 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
configuring by "/opt/ros/melodic/share/euslisp/jskeus/eus//lib/eusrt.l"
;; readmacro ;; object ;; packsym ;; common ;; constants ;; stream ;; string ;; loader ;; pprint 
;; process ;; hashtab ;; array ;; mathtran ;; eusdebug ;; eusforeign ;; extnum ;; coordinates 
;; tty ;; history ;; toplevel ;; trans ;; comp ;; builtins ;; par ;; intersection ;; geoclasses 
;; geopack ;; geobody ;; primt ;; compose ;; polygon ;; viewing ;; viewport ;; viewsurface 
;; hid ;; shadow ;; bodyrel ;; dda ;; helpsub ;; eushelp ;; fstringdouble 
EusLisp 9.29() for Linux64 created on ip-10-0-1-68(Tue Mar 1 05:47:01 PST 2022)
1.eus$ *program-name*
"/opt/ros/melodic/share/euslisp/jskeus/eus/Linux64/bin/eus"
```