### PR TITLE
[WSL] XFonts is not available on wslg: Try to use default font set if…

### DIFF
--- a/lisp/xwindow/Xtop.l
+++ b/lisp/xwindow/Xtop.l
@@ -232,6 +232,9 @@
 	(setq font-helvetica-12 (font-id "*-Helvetica-Medium-R-Normal-*-12-*"))
 	(setq font-a14 (font-id "*-fixed-medium-r-normal-*-14-*"))
 
+	(when (zerop font-cour12)  ;; If we can not find font-cour12, use default value for all element
+	  (setq font-cour12 (font-id "*-*-*-*-*-*-*-*")))
+
 	(when (zerop font-cour12)  ;; this is default gc
 	  (setq *display* 0)
 	  (warning-message 1 "~%Xserver connection failed due to missing font server, please try after computer restarts~%")


### PR DESCRIPTION
… font-cour12 is not found

with out this patch, eus fails when it uses `GC`. c.f. https://github.com/microsoft/wslg/issues/310
```
k-okada@SurfacePro8:~/catkin_ws/ws_euslisp/src/euslisp$ eusx
configuring by "/home/k-okada/catkin_ws/ws_euslisp/devel/share/euslisp/jskeus/eus//lib/eusrt.l"
;; readmacro ;; object ;; packsym ;; common ;; constants ;; stream ;; string ;; loader ;; pprint ;; process ;; hashtab ;; array ;; mathtran ;; eusdebug ;; eusforeign ;; extnum ;; coordinates ;; tty ;; history ;; toplevel ;; trans ;; comp ;; builtins ;; par ;; intersection ;; geoclasses ;; geopack ;; geobody ;; primt ;; compose ;; polygon ;; viewing ;; viewport ;; viewsurface ;; hid ;; shadow ;; bodyrel ;; dda ;; helpsub ;; eushelp ;; xforeign ;; Xdecl ;; Xgraphics ;; Xcolor ;; Xeus ;; Xevent ;; Xpanel ;; Xitem ;; Xtext ;; Xmenu ;; Xscroll ;; Xcanvas ;; Xtop ;; Xapplwin
connected to Xserver DISPLAY=:0
can't load font "*-courier-medium-r-*-8-*"can't load font "*-courier-medium-r-*-10-*"can't load font "*-courier-medium-r-*-12-*"can't load font "*-courier-medium-r-*-14-*"can't load font "*-courier-medium-r-*-18-*"can't load font "*-courier-bold-r-*-12-*"can't load font "*-courier-bold-r-*-14-*"can't load font "*-courier-bold-r-*-18-*"can't load font "*-courier-bold-r-*-24-*"can't load font "*-times-medium-r-*-10-*"can't load font "*-times-medium-r-*-12-*"can't load font "*-times-bold-r-*-12-*"can't load font "*-times-bold-r-*-14-*"can't load font "*-times-bold-r-*-18-*"can't load font "*-times-bold-r-*-24-*"can't load font "lucidasans-bold-12"can't load font "lucidasans-bold-14"can't load font "*-Helvetica-Bold-R-Normal-*-12-*"can't load font "*-Helvetica-Medium-R-Normal-*-12-*"can't load font "*-fixed-medium-r-normal-*-14-*"
Xserver connection failed due to missing font server, please try after computer restarts
;; pixword ;; RGBHLS ;; convolve ;; piximage ;; pbmfile ;; image_correlation ;; fstringdouble
EusLisp 9.29(7b154531) for Linux64 created on SurfacePro8(Wed Oct 5 08:22:00 JST 2022)
1.eusx$ (view)
Call Stack (max depth: 20):
  0: at (view)
  1: at (view)
  2: at (view)
  3: at #<compiled-code #X561bb77f2750>
eusx 0 error: ;; visual-depth: no such visual nil registered. in (view)
2.E1-eusx$ exit
```