### PR TITLE
Fix rotate-vertices when an axis argument is float-vector

### DIFF
--- a/lisp/geo/geobody.l
+++ b/lisp/geo/geobody.l
@@ -116,14 +116,14 @@
     ;(send-all (send self :primitive-bodies) :translate-vertices trans self)
     self)
  (:rotate-vertices (rad axis)
-	;move all vertices with respect to this coordinates
-	;without moving coordinates.
+    ;move all vertices with respect to this coordinates
+    ;without moving coordinates.
     (let (rotmat)
-	(if (float-vector-p axis) (setq rotmat (rotation-matrix rad axis)))
-        (dolist (v model-vertices)
-	   (if (float-vector-p axis)
-	       (transform rotmat v v)
-	       (rotate-vector v rad axis v))))
+      (if (float-vector-p axis) (setq rotmat (rotation-matrix rad axis)))
+      (dolist (v model-vertices)
+        (if (float-vector-p axis)
+            (transform rotmat v v)
+            (rotate-vector v rad axis v))))
     (send self :update)
 ;    (send-all (send self :primitive-bodies) :rotate-vertices rad axis self)
     self)

--- a/lisp/geo/geobody.l
+++ b/lisp/geo/geobody.l
@@ -119,7 +119,7 @@
 	;move all vertices with respect to this coordinates
 	;without moving coordinates.
     (let (rotmat)
-	(if (float-vector-p axis) (setq rotmat (rotation rad axis)))
+	(if (float-vector-p axis) (setq rotmat (rotation-matrix rad axis)))
         (dolist (v model-vertices)
 	   (if (float-vector-p axis)
 	       (transform rotmat v v)


### PR DESCRIPTION
This PR fixes the bug reported in #499.
When we input `axis` argument as float-vector in :rotate-vertices, the following error occurs because `rotation` is not defined.
`rotation-matrix` has to be used.


```lisp
1.irteusgl$ (setq a (make-cube 10 20 30))
#<body #X560935170790 (:cube 10.0 20.0 30.0) 0.0 0.0 0.0 / 0.0 0.0 0.0>
2.irteusgl$ (send a :rotate-vertices pi/2 #f(0 0 1))
Call Stack (max depth: 20):
  0: at (send a :rotate-vertices pi/2 #f(0.0 0.0 1.0))
  1: at (send a :rotate-vertices pi/2 #f(0.0 0.0 1.0))
  2: at #<compiled-code #X560934d3e3d8>
irteusgl 0 error: undefined function geometry::rotation in (send a :rotate-vertices pi/2 #f(0.0 0.0 1.0))
```

cc: @poyotamu000 @Affonso-Gui 