### PR TITLE
rewrite Fix rotate-vertices when an axis argument is float-vector

### DIFF
--- a/lisp/geo/geobody.l
+++ b/lisp/geo/geobody.l
@@ -119,7 +119,7 @@
 	;move all vertices with respect to this coordinates
 	;without moving coordinates.
     (let (rotmat)
-	(if (float-vector-p axis) (setq rotmat (rotation rad axis)))
+	(if (float-vector-p axis) (setq rotmat (rotation-matrix rad axis)))
         (dolist (v model-vertices)
 	   (if (float-vector-p axis)
 	       (transform rotmat v v)

--- a/test/geo.l
+++ b/test/geo.l
@@ -84,6 +84,19 @@
       ))
   )
 
+;; test to check https://github.com/euslisp/EusLisp/issues/499
+(deftest rotate-vertices ()
+  (let ((a (make-cube 10 20 30)) v0 v1)
+    (setq v0 (copy-object (send a :vertices)))
+    (send a :rotate-vertices pi/2 #f(0 0 1))
+    (setq v1 (send a :vertices))
+    (dotimes (i (length v0))
+      (assert (eps= (elt (elt v0 i) 0) (elt (elt v1 i) 1)))
+      (assert (eps= (elt (elt v0 i) 1) (- (elt (elt v1 i) 0))))
+      (assert (eps= (elt (elt v0 i) 2) (elt (elt v1 i) 2)))
+      )
+    ))
+
 (eval-when (load eval)
   (run-all-tests)
   (exit))


### PR DESCRIPTION
c.f. https://github.com/euslisp/EusLisp/pull/500

add test to check https://github.com/euslisp/EusLisp/issues/499