### PR TITLE
[doc/jlatex/jsysfunc.tex] fix document of cd. add document of pwd.

### DIFF
--- a/doc/jlatex/jsysfunc.tex
+++ b/doc/jlatex/jsysfunc.tex
@@ -783,7 +783,10 @@ emacsの上でも{\tt M-X run-lisp}命令でおなじことが可能である。
 \begin{refdesc}
 
 \funcdesc{cd}{\&optional (dir (unix:getenv "HOME"))}{
-現在のディレクトリを変更する。}
+現在のディレクトリを変更する。{\em dir}がsymbolの場合、{\em dir}を評価せずに文字列として扱う。}
+
+\funcdesc{pwd}{}{
+現在のディレクトリを返す。}
 
 \funcdesc{ez}{\&optional key}{
 ezエディターの画面に入る。それからLisp書式を読み込み、

--- a/doc/latex/sysfunc.tex
+++ b/doc/latex/sysfunc.tex
@@ -810,7 +810,10 @@ Similar function is available on emacs by M-X run-lisp command.
 \begin{refdesc}
 
 \funcdesc{cd}{\&optional (dir (unix:getenv "HOME"))}{
-changes the current working directory.}
+changes the current working directory. If {\em dir} is a symbol, {\em dir} is not evaluated and converted to string.}
+
+\funcdesc{pwd}{}{
+gets current working directory.}
 
 \funcdesc{ez}{\&optional key}{
 enters display editor ez, and reads Lisp forms from it, and evaluates


### PR DESCRIPTION
https://github.com/euslisp/EusLisp/issues/505 の内容をドキュメントに追加しました。また、cd関数の下に定義されているpwd関数がドキュメントに載っていなかったので、ついでに追加しました。

https://github.com/euslisp/EusLisp/blob/25a473c431559f62a18707f91ca5c1fa70feea5e/lisp/l/process.l#L12-L15

texのファイル以外にhtmlのファイルにもドキュメントが存在するようなのですが、こちらも更新するべきでしょうか?

https://github.com/euslisp/EusLisp/blob/25a473c431559f62a18707f91ca5c1fa70feea5e/doc/html/jmanual-node86.html#L100-L110

https://github.com/euslisp/EusLisp/blob/25a473c431559f62a18707f91ca5c1fa70feea5e/doc/html/jmanual-node14.html#L2202-L2213