### PR TITLE
fix euslisp: FTBFS: jpegmemcd.c:29:3: error: implicit declaration of function ‘jpeg_memio_dest’

### DIFF
--- a/lisp/image/jpeg/jpegmemcd.c
+++ b/lisp/image/jpeg/jpegmemcd.c
@@ -11,8 +11,17 @@
 #include <stdio.h>
 #include "jpeglib.h"
 #include <setjmp.h>
+
+#if JPEG_LIB_VERSION >= 80 || defined(MEM_SRCDST_SUPPORTED)
+#define jpeg_memio_dest(cinfo, outbuffer, outsize) \
+  jpeg_mem_dest((j_compress_ptr)cinfo, (unsigned char **)outbuffer, (unsigned long *)outsize)
+
+#define jpeg_memio_src(cinfo, inbuffer, insize) \
+  jpeg_mem_src((j_decompress_ptr)cinfo, (const unsigned char *)inbuffer, (unsigned long)insize)
+#else
 GLOBAL(void) jpeg_memio_dest (j_compress_ptr cinfo, JOCTET *jpegimgbuf, long *size);
 GLOBAL(void) jpeg_memio_src (j_decompress_ptr cinfo, JOCTET *buf, long size);
+#endif
 
 
 int JPEG_compress(JSAMPLE *image_buffer, long width, long height,


### PR DESCRIPTION
see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1066307

This is most likely caused by a change in dpkg 1.22.6, that enabled
-Werror=implicit-function-declaration. For more information, see
https://wiki.debian.org/qa.debian.org/FTBFS#A2024-03-13_-Werror.3Dimplicit-function-declaration