### PR TITLE
apply patches from debian/patches

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -95,8 +95,8 @@ if [[ "$QEMU" != "" ]]; then
     export GIT_SSL_NO_VERIFY=1
     git clone http://salsa.debian.org/science-team/euslisp /tmp/euslisp-dfsg
     for file in $(cat /tmp/euslisp-dfsg/debian/patches/series); do
-        # skip patches already applied by https://github.com/euslisp/EusLisp/pull/482
-        [[ $file =~ use-rtld-global-loadelf.patch|fix-arm-ldflags.patch|fix-library-not-linked-against-libc.patch|fix-manpage-has-bad-whatis-entry-on-man-pages.patch|fix-jpegmemcd-compile-error.patch ]] && continue;
+        # skip patches already applied by https://github.com/euslisp/EusLisp/pull/482, https://github.com/euslisp/EusLisp/pull/511
+        [[ $file =~ use-rtld-global-loadelf.patch|fix-arm-ldflags.patch|fix-library-not-linked-against-libc.patch|fix-manpage-has-bad-whatis-entry-on-man-pages.patch|fix-jpegmemcd-compile-error.patch|install-bin-lib-man-to-destdir.patch|install-eusjpeg-lib.patch ]] && continue;
         # skip patch already applied by https://github.com/euslisp/EusLisp/pull/441, https://github.com/euslisp/EusLisp/pull/509
         if [[ $file =~  fix-for-reprotest.patch ]]; then
             filterdiff -p1 -x 'lisp/image/jpeg/makefile' -x 'lisp/comp/comp.l' < /tmp/euslisp-dfsg/debian/patches/$file > /tmp/euslisp-dfsg/debian/patches/$file-fix

--- a/lisp/Makefile.generic1
+++ b/lisp/Makefile.generic1
@@ -6,7 +6,7 @@
 # EUSDIR=/usr/local/eus/
 # the directory where resulted executables should be installed
 
-PUBBINDIR=/usr/local/bin
+PUBDIR=/usr/
 
 # directories under EUSDIR
 # All architecture dependent object files go to OBJDIR.

--- a/lisp/Makefile.generic2
+++ b/lisp/Makefile.generic2
@@ -358,16 +358,31 @@ doc/latex/manual.dvi:	$(DOC)
 	(cd doc/latex; jlatex manual ; makeindex manual.idx ; jlatex manual)
 
 install:
-	(rm -f $(PUBBINDIR)/eus $(PUBBINDIR)/eusx $(PUBBINDIR)/euscomp;\
-	 cp $(BINDIR)/eus $(PUBBINDIR);\
-	 cp $(BINDIR)/eusx $(PUBBINDIR);\
-	 ln -sf eus $(PUBBINDIR)/euscomp)
+	install -d $(DESTDIR)$(PUBDIR)/lib
+	install -t $(DESTDIR)$(PUBDIR)/lib $(ADLIBDIR)/$(LIBEUSX)  $(ADLIBDIR)/$(LIBEUSGEO)  $(ADLIBDIR)/$(LIBEUSGL)
+	install -d $(DESTDIR)$(PUBDIR)/bin
+	install -t $(DESTDIR)$(PUBDIR)/bin $(BINDIR)/eus $(BINDIR)/eus0 $(BINDIR)/eus1 $(BINDIR)/eus2 $(BINDIR)/eusg $(BINDIR)/eusx $(BINDIR)/eusgl
+	ln -sf eus $(DESTDIR)$(PUBDIR)/bin/euscomp
+	install -d $(DESTDIR)$(PUBDIR)/share/man/man1/
+	install -t $(DESTDIR)$(PUBDIR)/share/man/man1/ $(EUSDIR)/doc/man/eus.1
+	ln -sf eus.1 $(DESTDIR)$(PUBDIR)/share/man/man1/eus0.1
+	ln -sf eus.1 $(DESTDIR)$(PUBDIR)/share/man/man1/eus1.1
+	ln -sf eus.1 $(DESTDIR)$(PUBDIR)/share/man/man1/eus2.1
+	ln -sf eus.1 $(DESTDIR)$(PUBDIR)/share/man/man1/eusg.1
+	ln -sf eus.1 $(DESTDIR)$(PUBDIR)/share/man/man1/eusx.1
+	ln -sf eus.1 $(DESTDIR)$(PUBDIR)/share/man/man1/eusgl.1
+	ln -sf eus.1 $(DESTDIR)$(PUBDIR)/share/man/man1/euscomp.1
+	install -d $(DESTDIR)$(PUBDIR)/share/doc/euslisp-doc
+	install -t $(DESTDIR)$(PUBDIR)/share/doc/euslisp-doc $(EUSDIR)/doc/*/*.pdf
+
 clean:
 	-rm -fr $(EUSDIR)/data/* 
-	-rm -f $(OBJDIR)/* $(ADLIBDIR)/libeus* $(BINDIR)/* $(LDIR)/constants.l.[co]\
+	-rm -f $(OBJDIR)/* $(ADLIBDIR)/eusmap $(ADLIBDIR)/libeus* $(BINDIR)/* $(LDIR)/constants.l.[co]\
 		$(LDIR)/eusstart.l.[co] $(COMPDIR)/builtins.l.[co] so_locations
 	-sh tool/clean-ch.sh
-	-rm -f $(CDIR)/makedate.c
+	-rm -f $(CDIR)/makedate.c $(EUSDIR)/include
+	-rmdir --ignore-fail-on-non-empty $(OBJDIR) $(ADLIBDIR) $(BINDIR)
+	-rmdir --ignore-fail-on-non-empty $(EUSDIR)/$(ARCH)
 
 eustag : 
 	$(BINDIR)/eustags \

--- a/lisp/image/jpeg/makefile
+++ b/lisp/image/jpeg/makefile
@@ -55,3 +55,6 @@ $(OBJDIR)/jmemdst.o:	jmemdst.c
 clean:
 	rm -f $(OBJFILES) $(LIBDIR)/jpegmemcd.$(LSFX) eusjpeg.c eusjpeg.h
 
+install: $(LIBDIR)/jpegmemcd.$(LSFX)
+	install -d $(DESTDIR)/usr/lib/
+	install -m 644 $(LIBDIR)/jpegmemcd.$(LSFX) $(DESTDIR)/usr/lib/


### PR DESCRIPTION
d54c8643 (Kei Okada, 4 minutes ago)
   install files with DESTDIR
    update lisp/Makefile.generic{1,2} to install executives, library and
    manuals to DESTDIR/PUBDIR/{bin,lib,share/man} by make install command

    copied from   https://salsa.debian.org/science-team/euslisp/-/blob/debian/9.29+dfsg-1/debian/patches/install-bin-lib-man-to-destdir.patch?ref_type=tags

4c6af251 (Kei Okada, 10 minutes ago)
    Add install target to image/jpeg/makefile
      Add install target to image/jpeg/makefile. This will install jpegmemcd.so  to PREFIX/lib

    copied from https://salsa.debian.org/science-team/euslisp/-/blob/debian/9.29+dfsg-1/debian/patches/install-eusjpeg-lib.patch?ref_type=tags