### PR TITLE
doc/*latex/*geometry.tex: fix typo extreme -> extream,

### DIFF
--- a/doc/jlatex/jgeometry.tex
+++ b/doc/jlatex/jgeometry.tex
@@ -179,7 +179,7 @@ xy-,yz-やzx-平面に平行な面を境界とする最小の四角柱を定義�
 このメソッドは、{\bf :intersection}よりも速い。なぜなら、新しい
 {\bf bounding-box}のインスタンスを作らないためである。}
 
-\methoddesc{:extreme-point}{direction}{
+\methoddesc{:extream-point}{direction}{
 この{\bf bounding-box}の８つの頂点の中で、{\em direction}との内積が最大のものを
 返す。}
 

--- a/doc/latex/geometry.tex
+++ b/doc/latex/geometry.tex
@@ -194,7 +194,7 @@ NIL otherwise.
 This method is faster than {\bf :intersection} because no new instance
 of bounding-box is created.}
 
-\methoddesc{:extreme-point}{direction}{
+\methoddesc{:extream-point}{direction}{
 returns one of the eight corner points yielding the largest dot-product 
 with {\em direction}.}
 


### PR DESCRIPTION

- the function name is `extream-point`,  see https://github.com/euslisp/EusLisp/blob/b0dfd7e4feb737909bed67541bf5c6b526c46a4b/lisp/geo/geobody.l#L243

- lintien issue
![Screenshot from 2024-04-19 10-22-05](https://github.com/euslisp/EusLisp/assets/493276/53ba6c33-437b-4905-a5af-4021b3a73405)
