### PR TITLE
Fix for blhf Fix for blhc tests, we need to use default CFLAGS

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -95,8 +95,8 @@ if [[ "$QEMU" != "" ]]; then
     export GIT_SSL_NO_VERIFY=1
     git clone http://salsa.debian.org/science-team/euslisp /tmp/euslisp-dfsg
     for file in $(cat /tmp/euslisp-dfsg/debian/patches/series); do
-        # skip patches already applied by https://github.com/euslisp/EusLisp/pull/482, https://github.com/euslisp/EusLisp/pull/511
-        [[ $file =~ use-rtld-global-loadelf.patch|fix-arm-ldflags.patch|fix-library-not-linked-against-libc.patch|fix-manpage-has-bad-whatis-entry-on-man-pages.patch|fix-jpegmemcd-compile-error.patch|install-bin-lib-man-to-destdir.patch|install-eusjpeg-lib.patch|fix-lintian-typo.patch|fix-makefile-linux-MACHINE.patch|fix-makefile-generic1-version.patch ]] && continue;
+        # skip patches already applied by https://github.com/euslisp/EusLisp/pull/482, https://github.com/euslisp/EusLisp/pull/511, https://github.com/euslisp/EusLisp/pull/523
+        [[ $file =~ use-rtld-global-loadelf.patch|fix-arm-ldflags.patch|fix-library-not-linked-against-libc.patch|fix-manpage-has-bad-whatis-entry-on-man-pages.patch|fix-jpegmemcd-compile-error.patch|install-bin-lib-man-to-destdir.patch|install-eusjpeg-lib.patch|fix-lintian-typo.patch|fix-makefile-linux-MACHINE.patch|fix-makefile-generic1-version.patch|fix-for-blhc.patch ]] && continue;
         # skip patch already applied by https://github.com/euslisp/EusLisp/pull/441, https://github.com/euslisp/EusLisp/pull/509, https://github.com/euslisp/EusLisp/pull/512, https://github.com/euslisp/EusLisp/pull/514, https://github.com/euslisp/EusLisp/pull/517
         if [[ $file =~  fix-for-reprotest.patch ]]; then
             filterdiff -p1 -x 'lisp/image/jpeg/makefile' -x 'lisp/comp/comp.l' < /tmp/euslisp-dfsg/debian/patches/$file > /tmp/euslisp-dfsg/debian/patches/$file-fix

--- a/lisp/comp/comp.l
+++ b/lisp/comp/comp.l
@@ -24,7 +24,7 @@
 (eval-when (load eval)
 
 (defparameter *coptflags* "")
-(defparameter *cflags* "")
+(defparameter *cflags* (format nil " ~A" (or (unix::getenv "CFLAGS") "")))
 (defparameter *defun-list* nil)
 (defparameter *verbose* nil)
 (defparameter *optimize* 2)
@@ -1264,7 +1264,6 @@
 	 (setq file (merge-pathnames ".l" file))
          (if (null (probe-file  file)) 
 	     (error "file ~A not found~%" file)))
-      (warn "compiling file: ~A~%" (namestring file))
       (setq ins (open file))
       (setq *defun-list* nil)
       (when *multipass-optimize*


### PR DESCRIPTION
Changes:

 3721621a (Kei Okada, 19 seconds ago)
    .travis.sh: skip patches already applied

 34fe5a52 (Kei Okada, 5 days ago)
    copied from
    https://salsa.debian.org/science-team/euslisp/-/tree/master/debian/patches?ref_type=heads:
    Fix for blhf Fix for blhc tests, we need to use default CFLAGS