### PR TITLE
On arm32, localtime_r in LOCALTIME in unixcall.c returns NULL in some situation.

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -95,8 +95,8 @@ if [[ "$QEMU" != "" ]]; then
     export GIT_SSL_NO_VERIFY=1
     git clone http://salsa.debian.org/science-team/euslisp /tmp/euslisp-dfsg
     for file in $(cat /tmp/euslisp-dfsg/debian/patches/series); do
-        # skip patches already applied by https://github.com/euslisp/EusLisp/pull/482, https://github.com/euslisp/EusLisp/pull/511
-        [[ $file =~ use-rtld-global-loadelf.patch|fix-arm-ldflags.patch|fix-library-not-linked-against-libc.patch|fix-manpage-has-bad-whatis-entry-on-man-pages.patch|fix-jpegmemcd-compile-error.patch|install-bin-lib-man-to-destdir.patch|install-eusjpeg-lib.patch|fix-lintian-typo.patch|fix-makefile-linux-MACHINE.patch|fix-makefile-generic1-version.patch ]] && continue;
+        # skip patches already applied by https://github.com/euslisp/EusLisp/pull/482, https://github.com/euslisp/EusLisp/pull/511, https://github.com/euslisp/EusLisp/pull/524
+        [[ $file =~ use-rtld-global-loadelf.patch|fix-arm-ldflags.patch|fix-library-not-linked-against-libc.patch|fix-manpage-has-bad-whatis-entry-on-man-pages.patch|fix-jpegmemcd-compile-error.patch|install-bin-lib-man-to-destdir.patch|install-eusjpeg-lib.patch|fix-lintian-typo.patch|fix-makefile-linux-MACHINE.patch|fix-makefile-generic1-version.patch|fix-localtime-arm32.patch ]] && continue;
         # skip patch already applied by https://github.com/euslisp/EusLisp/pull/441, https://github.com/euslisp/EusLisp/pull/509, https://github.com/euslisp/EusLisp/pull/512, https://github.com/euslisp/EusLisp/pull/514, https://github.com/euslisp/EusLisp/pull/517
         if [[ $file =~  fix-for-reprotest.patch ]]; then
             filterdiff -p1 -x 'lisp/image/jpeg/makefile' -x 'lisp/comp/comp.l' < /tmp/euslisp-dfsg/debian/patches/$file > /tmp/euslisp-dfsg/debian/patches/$file-fix

--- a/lisp/c/unixcall.c
+++ b/lisp/c/unixcall.c
@@ -142,6 +142,7 @@ pointer argv[];
   if (n==1) clock=coerceintval(argv[0]);
   else clock=time(0);
   tms=localtime_r((time_t *)&clock,&res); /* localtime-->localtime_r */
+  if (tms == NULL) tms = &res;
   timevec=makevector(C_VECTOR,10);
   vpush(timevec);
 


### PR DESCRIPTION
copied from https://salsa.debian.org/science-team/euslisp/-/tree/master/debian/patches?ref_type=heads: On arm32, localtime_r in LOCALTIME in unixcall.c returns NULL in some situation.
