### PR TITLE
Support apple silicon arm architecture

### DIFF
--- a/lisp/Makefile.Darwin
+++ b/lisp/Makefile.Darwin
@@ -42,22 +42,36 @@ endif
 
 # Pentium's arch returns 'i586', which is ignored by conditionals in c/*.[ch].
 OS_VERSION=$(shell sw_vers -productVersion | sed s/\.[^.]*$$//)
+ARCH_TYPE=$(shell uname -m)
 ifeq ($(OS_VERSION), 10.5) 
  MACHINE=i386
 else
- MACHINE=x86_64
- ALIGN_FUNCTIONS=-falign-functions=8 -fPIC
+ ifeq ($(ARCH_TYPE), arm64)
+  MACHINE=arm64
+  ALIGN_FUNCTIONS=-falign-functions=8 -fPIC
+ else
+  MACHINE=x86_64
+  ALIGN_FUNCTIONS=-falign-functions=8 -fPIC
+ endif
 endif
 DEBUG= -g
 
 # If you use libc.so.5, remove -DLIB6 option.
 # In order to include thread library, libc.so.6 is preferrable.
 
+ifeq ($(MACHINE), arm64)
+CFLAGS=-D$(MACHINE) -Daarch64 -Wno-return-type -DLinux -D_REENTRANT -DVERSION=\"$(VERSION)\" -DDarwin \
+	-DLIB6 $(ALIGN_FUNCTIONS)  \
+        $(DEBUG) $(CPU_OPTIMIZE) $(THREAD) -D$(XVERSION) \
+	-DGCC $(GCC3) \
+        -I/usr/include -I/opt/local/include -I/opt/homebrew/include -I/usr/local/include -I/opt/X11/include -I$(EUSDIR)/include
+else
 CFLAGS=-D$(MACHINE) -Wno-return-type -DLinux -D_REENTRANT -DVERSION=\"$(VERSION)\" -DDarwin \
 	-DLIB6 $(ALIGN_FUNCTIONS)  \
         $(DEBUG) $(CPU_OPTIMIZE) $(THREAD) -D$(XVERSION) \
 	-DGCC $(GCC3) \
-        -I/usr/include -I/opt/local/include -I/opt/X11/include -I$(EUSDIR)/include
+        -I/usr/include -I/opt/local/include -I/opt/homebrew/include -I/usr/local/include -I/opt/X11/include -I$(EUSDIR)/include
+endif
 
 # Use gcc for C-compiling on SunOS4. Sun's cc is ok on Solaris.
 # /usr/ucb/cc cannot compile because of its incapability of recognizing
@@ -78,11 +92,11 @@ LD=gcc
 # On Solaris, XLIB and EUSLIB are combined together into lib/libeusx.so.
 
 RAWLIB=-ldl -lm -lpthread
-XLIB= -L/opt/local/lib -L/opt/X11/lib -lX11
+XLIB= -L/opt/local/lib -L/opt/homebrew/lib -L/usr/local/lib -L/opt/X11/lib -lX11
 
 # specify directories where euslisp's libraries are located.
 EUSLIB= -L$(ADLIBDIR)
-GLLIB= -L$/opt/X11/lib -lGLU -lGL -lXext -leusgl
+GLLIB= -L/opt/homebrew/lib -L/usr/local/lib -L/opt/X11/lib -lGLU -lGL -lXext -leusgl
 
 # POSIX Thread 
 THREADDEP=mthread_posix.c

--- a/lisp/c/eus.c
+++ b/lisp/c/eus.c
@@ -30,7 +30,11 @@ unsigned int thr_self() { return(1);}
 #include <malloc.h> // define mallopt, M_MMAP_MAX
 #endif
 #if Darwin
+#ifdef aarch64
+void *_end;
+#else
 int _end;
+#endif
 #endif
 
 /*variables*/

--- a/lisp/c/eval.c
+++ b/lisp/c/eval.c
@@ -714,7 +714,8 @@ __asm__ (".align 8\n"
 
 #if aarch64
 __asm__ (".align 8\n"
-         "exec_function_i:\n\t"
+         ".global _exec_function_i\n"
+         "_exec_function_i:\n\t"
 	 "sub	sp, sp, #192\n\t" // 128(8x16) + 64
 	 "stp	x29, x30, [sp, 128]\n\t"
 	 "add	x29, sp, 128\n\t"
@@ -726,18 +727,18 @@ __asm__ (".align 8\n"
 	 // vargv -> stack
 	 "mov	x1, 0\n\t"
 	 "ldr	x2, [x29, 24]\n\t"
-	 "b	.FUNCII_LPCK\n\t"
-	 ".FUNCII_LP:\n\t"
+	 "b	1f\n\t"
+	 "0:\n\t"
 	 "lsl	x0, x1, 3\n\t"
 	 "add	x3, x2, x0\n\t" // vargv[i]
 	 "add	x4, sp, x0\n\t" // stack[i]
 	 "ldr	x0, [x3]\n\t"
 	 "str	x0, [x4]\n\t" // push stack
 	 "add	x1, x1, 1\n\t"
-	 ".FUNCII_LPCK:\n\t"
+	 "1:\n\t"
 	 "ldr	x5, [x29, 32]\n\t"
 	 "cmp	x1, x5\n\t"
-	 "blt	.FUNCII_LP\n\t"
+	 "blt	0b\n\t"
 	 // fargv -> register
 	 "ldr	x0, [x29, 40]\n\t" // fargv
 	 "ldr	d0, [x0]\n\t"
@@ -782,7 +783,8 @@ __asm__ (".align 8\n"
 	 );
 
 __asm__ (".align 8\n"
-         "exec_function_f:\n\t"
+         ".global _exec_function_f\n"
+         "_exec_function_f:\n\t"
 	 "sub	sp, sp, #192\n\t" // 128(8x16) + 64
 	 "stp	x29, x30, [sp, 128]\n\t"
 	 "add	x29, sp, 128\n\t"
@@ -794,18 +796,18 @@ __asm__ (".align 8\n"
 	 // vargv -> stack
 	 "mov	x1, 0\n\t"
 	 "ldr	x2, [x29, 24]\n\t"
-	 "b	.FUNCFF_LPCK\n\t"
-	 ".FUNCFF_LP:\n\t"
+	 "b	3f\n\t"
+	 "2:\n\t"
 	 "lsl	x0, x1, 3\n\t"
 	 "add	x3, x2, x0\n\t" // vargv[i]
 	 "add	x4, sp, x0\n\t" // stack[i]
 	 "ldr	x0, [x3]\n\t"
 	 "str	x0, [x4]\n\t" // push stack
 	 "add	x1, x1, 1\n\t"
-	 ".FUNCFF_LPCK:\n\t"
+	 "3:\n\t"
 	 "ldr	x5, [x29, 32]\n\t"
 	 "cmp	x1, x5\n\t"
-	 "blt	.FUNCFF_LP\n\t"
+	 "blt	2b\n\t"
 	 // fargv -> register
 	 "ldr	x0, [x29, 40]\n\t" // fargv
 	 "ldr	d0, [x0]\n\t"

--- a/lisp/c/printer.c
+++ b/lisp/c/printer.c
@@ -210,10 +210,18 @@ pointer f;
     writestr(f,(byte *)work,len); }}
 
 static void printhex(val,f)
+#ifdef aarch64
+long val;
+#else
 int val;
+#endif
 pointer f;
 { char work[20];
+#ifdef aarch64
+  sprintf(work,"#x%lx",val);
+#else
   sprintf(work,"#x%x",val);
+#endif
   writestr(f,(byte *)work,strlen(work));}
 
 static void printratio(ctx,rat,f, base)
@@ -296,7 +304,11 @@ context *ctx;
   writestr(f,(byte *)"#<",2);
   printsym(ctx,class->c.cls.name,f);
   writech(f,' ');
-  printhex(obj,f);
+#ifdef aarch64
+  printhex((long)obj,f);
+#else
+  printhex((int)obj,f);
+#endif
   writech(f,'>');}
 
 static void printpkg(p,f)
@@ -359,7 +371,11 @@ int prlevel;
 	  break;
     case ELM_BYTE:
 	  writestr(f,(byte *)"#<bytecode ",11);
-	  printhex(vec,f);
+#ifdef aarch64
+	  printhex((long)vec,f);
+#else
+	  printhex((int)vec,f);
+#endif
 	  writech(f,'>');
 	  break;
     case ELM_CHAR:
@@ -385,7 +401,7 @@ int prlevel;
 	  break;
     case ELM_FOREIGN:
 	  writestr(f,(byte *)"#u",2);
-	  printstr(ctx,vecsize(vec),vec->c.ivec.iv[0],f);
+	  printstr(ctx,vecsize(vec),(byte *)vec->c.ivec.iv[0],f);
 	  break;
     default:
 	  if (classof(vec)==C_VECTOR)  writestr(f,(byte *)"#(",2);

--- a/lisp/image/jpeg/makefile
+++ b/lisp/image/jpeg/makefile
@@ -38,8 +38,8 @@ else
 CC += -fPIC
 endif
 ifeq ($(ARCHDIR), Darwin)
-CC += -I/opt/local/lib/jpeg6b/include -I/opt/local/include
-LD += -L/opt/local/lib/jpeg6b/lib     -L/opt/local/lib
+CC += -I/opt/local/lib/jpeg6b/include -I/opt/local/include -I/opt/homebrew/include -I/usr/local/include
+LD += -L/opt/local/lib/jpeg6b/lib     -L/opt/local/lib -L/opt/homebrew/lib -L/usr/local/lib
 endif
 ifeq ($(ARCHDIR), LinuxARM)
 CC += -fPIC

--- a/lisp/opengl/src/oglforeign.c.c
+++ b/lisp/opengl/src/oglforeign.c.c
@@ -32,14 +32,14 @@ char *xentry;
   entry=(eusinteger_t)dlsym((eusinteger_t)dlhandle, xentry);
   if ( !entry ) {
     dlhandle=(eusinteger_t)dlopen("cygGLU-1.dll", RTLD_LAZY);
-    entry=(eusinteger_t)dlsym(dlhandle, xentry);}
+    entry=(eusinteger_t)dlsym((void *)dlhandle, xentry);}
   if ( !entry ) {
     dlhandle=(eusinteger_t)dlopen(0, RTLD_LAZY);
-    entry=(eusinteger_t)dlsym(dlhandle, xentry);}
+    entry=(eusinteger_t)dlsym((void *)dlhandle, xentry);}
 #elif Darwin
   eusinteger_t dlhandle;
   dlhandle=(eusinteger_t)dlopen(0, RTLD_LAZY);
-  entry=(eusinteger_t)dlsym(dlhandle, xentry);
+  entry=(eusinteger_t)dlsym((void *)dlhandle, xentry);
 #else
 #if (WORD_SIZE == 64)
   entry=(eusinteger_t)dlsym((void *)((eusinteger_t)(sysmod->c.ldmod.handle) & ~3L), xentry);

--- a/lisp/xwindow/xforeign.c.c
+++ b/lisp/xwindow/xforeign.c.c
@@ -423,7 +423,7 @@ char *xentry;
    dlhandle=(eusinteger_t)dlopen("/usr/bin/cygX11-6.dll", RTLD_LAZY);
    if( dlhandle==0 )
      dlhandle=(eusinteger_t)dlopen("libX11.dll", RTLD_LAZY);
-   entry=(eusinteger_t)dlsym(dlhandle, xentry);
+   entry=(eusinteger_t)dlsym((void *)dlhandle, xentry);
 #elif Darwin
    eusinteger_t dlhandle;
    dlhandle=(eusinteger_t)dlopen("/opt/X11/lib/libX11.dylib", RTLD_LAZY);
@@ -431,7 +431,7 @@ char *xentry;
      dlhandle=(eusinteger_t)dlopen("/usr/local/lib/libX11.dylib", RTLD_LAZY);
    if( dlhandle==0 )
      dlhandle=(eusinteger_t)dlopen("libX11.dylib", RTLD_LAZY);
-   entry=(eusinteger_t)dlsym(dlhandle, xentry);
+   entry=(eusinteger_t)dlsym((void *)dlhandle, xentry);
 #else
   entry=(eusinteger_t)dlsym((void *)((eusinteger_t)(sysmod->c.ldmod.handle) & ~3), xentry);
 #endif


### PR DESCRIPTION
# Add support for Apple Silicon (arm64)
This PR introduces the necessary changes to build and run the software natively on Apple Silicon (macOS arm64 architecture).

## Key Changes:

Makefile: The build system for Darwin (macOS) now detects the arm64 architecture and sets the appropriate compiler flags. It also adds standard Homebrew paths (/opt/homebrew/) for libraries and includes.

## C & Assembly:

Corrects the linkage of assembly functions on arm64 to make them visible to the C linker.

Updates C code to handle 64-bit pointers correctly, especially for printing memory addresses.

Adjusts type definitions (_end symbol) and function calls (dlsym) for compatibility with the arm64 architecture.