### PR TITLE
Add github action test for macos-x and macos-x-arm64 (Apple Silicon)

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -196,7 +196,18 @@ jobs:
                exit 0"
 
   osx:
-    runs-on: macos-13  # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
+    strategy:
+      matrix:
+        include:
+          # https://github.com/actions/runner-images/tree/main/images/macos
+          # Note: To test macOS-14 with Intel architecture,
+          # you need to use the paid macOS-14-large runner, as macOS-14 is grouped with ARM-based runners.
+          # https://docs.github.com/en/actions/concepts/runners/about-larger-runners
+          - runs-on: macos-13  # Intel (x64)
+          - runs-on: macos-14  # ARM64 (Apple Silicon)
+          - runs-on: macos-15  # ARM64 (Apple Silicon)
+      fail-fast: false
+    runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 60
     steps:
       - name: Checkout


### PR DESCRIPTION
This adds ARM64 (Apple Silicon) runners to the macOS CI workflow, testing against macos-13, macos-14, and macos-15 for both Intel (x64) and Apple Silicon architectures.

Related to #529 

This test should be failed.