### PR TITLE
Fixed find symbol function by using 's' instead of 'sym' variable and added hash table size

### DIFF
--- a/lisp/l/packsym.l
+++ b/lisp/l/packsym.l
@@ -165,7 +165,9 @@
 	(cond ((eq sym 0) (return-from :find nil))
 	      ((eq sym 1) #|deleted mark -- do nothing|# )
 	      ((equal (sym . pname) (s . pname)) (return-from :find (mod hash size))))
-	(if (>= (setq hash (1+ hash)) (* 2 size)) (error "can not find ~a in this package" sym)))
+   (if (>= (setq hash (1+ hash)) (* 2 size))
+      (error "Cannot find symbol ~s. Search limit reached (~d slots). Hash table (size: ~d) may be full."
+           s (* 2 size) size)))
       nil))
  (:shadow (sym)
       (when (null (send self :find sym))


### PR DESCRIPTION
This pull request addresses a minor bug in the :find method for packages and significantly improves its error reporting for easier debugging.

- Fixed Incorrect Variable in Error Message: The error message previously used the `sym` variable, which could display the wrong symbol when a search failed. This has been corrected to use `s`, ensuring the message always shows the symbol that was actually being searched for.

- Enhanced Error Details: The error message has been expanded to be more informative. It now includes the search limit and the hash table's size, providing valuable context that can help diagnose a full hash table more quickly.


## Quick check

Check code
```
  (dotimes (i 100)
    (eval `(defconstant ,(intern (format nil "*CONST~d*" i)) i)))
  (make-package "TEST1")
  (dotimes (i (+ (length ((find-package "TEST1") . intsymvector)) 10))
    (eval `(defconstant ,(intern (format nil "TEST1::*CONST~d*" i)) i)))
  (make-package "TEST2")
  (dotimes (i (+ (length ((find-package "TEST2") . intsymvector)) 10))
    (print i)
    (catch 'error
      (labels ((error2 (&rest args) (print args *error-output*)(throw 'error nil)))
              (lisp::install-error-handler 'error2)
              (shadow (intern (format nil "*CONST~d*" i)) (find-package "TEST2"))
              (eval `(defconstant ,(intern (format nil "TEST2::*CONST~d*" i)) i)))))
```



Without this PR,
```
0
1
2
3
4
5
6
7
8
9
10
11
12
13
14
15
16
17
18
19
20
21
22
23
24
25
26
27
28
29
30
31
32
33
34
35
36
37
38
39
40
41
42
43
44
45
46
47
48
49
50
51
52
53
54
55
56
57
58
59
60
Call Stack (max depth: 20):
  0: at (shadow (intern (format nil "*CONST~d*" i)) (find-package "TEST2"))
  1: at (labels ((error2 (&rest args) (print args *error-output*) (throw 'error nil))) (lisp::install-error-handler 'error2) (shadow (intern (format nil "*CONST~d*" i)) (find-package "TEST2")) (eval (cons 'defconstant (cons (intern (format nil "TEST2::*CONST~d*" i)) (list 'i)))))
  2: at (catch 'error (labels ((error2 (&rest args) (print args *error-output*) (throw 'error nil))) (lisp::install-error-handler 'error2) (shadow (intern (format nil "*CONST~d*" i)) (find-package "TEST2")) (eval (cons 'defconstant (cons (intern (format nil "TEST2::*CONST~d*" i)) (list 'i))))))
  3: at (while (< i #:dotimes64) (print i) (catch 'error (labels ((error2 (&rest args) (print args *error-output*) (throw 'error nil))) (lisp::install-error-handler 'error2) (shadow (intern (format nil "*CONST~d*" i)) (find-package "TEST2")) (eval (cons 'defconstant (cons (intern (format nil "TEST2::*CONST~d*" i)) (list 'i)))))) (setq i (1+ i)))
  4: at (let ((i 0) (#:dotimes64 (+ (length ((find-package "TEST2") . intsymvector)) 10))) (declare (integer i #:dotimes64)) (while (< i #:dotimes64) (print i) (catch 'error (labels ((error2 (&rest args) (print args *error-output*) (throw 'error nil))) (lisp::install-error-handler 'error2) (shadow (intern (format nil "*CONST~d*" i)) (find-package "TEST2")) (eval (cons 'defconstant (cons (intern (format nil "TEST2::*CONST~d*" i)) (list 'i)))))) (setq i (1+ i))) nil)
  5: at (dotimes (i (+ (length ((find-package "TEST2") . intsymvector)) 10)) (print i) (catch 'error (labels ((error2 (&rest args) (print args *error-output*) (throw 'error nil))) (lisp::install-error-handler 'error2) (shadow (intern (format nil "*CONST~d*" i)) (find-package "TEST2")) (eval (cons 'defconstant (cons (intern (format nil "TEST2::*CONST~d*" i)) (list 'i)))))))
  6: at #<compiled-code #X15049b380>
(76 "" (shadow (intern (format nil "*CONST~d*" i)) (find-package "TEST2")) "can not find test2::*const27* in this package")
```

In this case `test2::*const27*` is not target symbol.

With this PR
```
0
1
2
3
4
5
6
7
8
9
10
11
12
13
14
15
16
17
18
19
20
21
22
23
24
25
26
27
28
29
30
31
32
33
34
35
36
37
38
39
40
41
42
43
44
45
46
47
48
49
50
51
52
53
54
55
56
57
58
59
60
Call Stack (max depth: 20):
  0: at (shadow (intern (format nil "*CONST~d*" i)) (find-package "TEST2"))
  1: at (labels ((error2 (&rest args) (print args *error-output*) (throw 'error nil))) (lisp::install-error-handler 'error2) (shadow (intern (format nil "*CONST~d*" i)) (find-package "TEST2")) (eval (cons 'defconstant (cons (intern (format nil "TEST2::*CONST~d*" i)) (list 'i)))))
  2: at (catch 'error (labels ((error2 (&rest args) (print args *error-output*) (throw 'error nil))) (lisp::install-error-handler 'error2) (shadow (intern (format nil "*CONST~d*" i)) (find-package "TEST2")) (eval (cons 'defconstant (cons (intern (format nil "TEST2::*CONST~d*" i)) (list 'i))))))
  3: at (while (< i #:dotimes64) (print i) (catch 'error (labels ((error2 (&rest args) (print args *error-output*) (throw 'error nil))) (lisp::install-error-handler 'error2) (shadow (intern (format nil "*CONST~d*" i)) (find-package "TEST2")) (eval (cons 'defconstant (cons (intern (format nil "TEST2::*CONST~d*" i)) (list 'i)))))) (setq i (1+ i)))
  4: at (let ((i 0) (#:dotimes64 (+ (length ((find-package "TEST2") . intsymvector)) 10))) (declare (integer i #:dotimes64)) (while (< i #:dotimes64) (print i) (catch 'error (labels ((error2 (&rest args) (print args *error-output*) (throw 'error nil))) (lisp::install-error-handler 'error2) (shadow (intern (format nil "*CONST~d*" i)) (find-package "TEST2")) (eval (cons 'defconstant (cons (intern (format nil "TEST2::*CONST~d*" i)) (list 'i)))))) (setq i (1+ i))) nil)
  5: at (dotimes (i (+ (length ((find-package "TEST2") . intsymvector)) 10)) (print i) (catch 'error (labels ((error2 (&rest args) (print args *error-output*) (throw 'error nil))) (lisp::install-error-handler 'error2) (shadow (intern (format nil "*CONST~d*" i)) (find-package "TEST2")) (eval (cons 'defconstant (cons (intern (format nil "TEST2::*CONST~d*" i)) (list 'i)))))))
  6: at #<compiled-code #X138010980>
(76 "" (shadow (intern (format nil "*CONST~d*" i)) (find-package "TEST2")) "Cannot find symbol *const60*. Search limit reached (120 slots). Hash table (size: 60) may be full.")
```
In this case `test2::*const60*` is target symbol and the program outputs correct error message.
