### PR TITLE
Add `:align-to` method

### DIFF
--- a/lisp/l/coordinates.l
+++ b/lisp/l/coordinates.l
@@ -103,6 +103,15 @@
 	    (transform-coords (send (send self :parentcoords)
 				    :inverse-transformation) cc cc)
 	    (send self :newcoords cc))))
+  (:align-to (c c2 &aux cc)
+     (unless (coordinates-p c) (error "coordinates expected for self-reference"))
+     (unless (coordinates-p c2) (error "coordinates expected for target"))
+     (setq cc (send c2 :copy-worldcoords))
+     (transform-coords cc
+                       (send (send c :copy-worldcoords) :inverse-transformation)
+                       cc)
+     (send self :transform cc :world)
+     self)
   (:rotate-vector (v) (transform rot v))
   (:transform-vector  (v)
    ;vector v given in the local coords is converted to world representation


### PR DESCRIPTION
## Proposed Feature:Object Alignment (`:align-to` method)

This PR introduces a new method to the `CASCADED-COORDS` class to simplify the essential operation of **aligning an object based on an internal reference point to a target world coordinate.**

### Goal and Use Case

The current `:move-to` method can only move an object based on its **representative coordinate system** (i.e. the object's single representative frame)．

**Use Case:** The `:move-to` command is inadequate when you need to align a **specific feature** (e.g. the handle or base of an object like a kettle) to a target frame (e.g. a hand or a table surface)．For me, I would like to align needle's specific coordinate to a target coordinate.

**The specific goal of this feature is:** To move the entire **moving object** (`*tool-body*`) so that its **internal reference coordinates** ($`\mathbf{C}_{\text{internal}}`$) precisely match the **target coordinates** ($`\mathbf{C}_{\text{target}}`$) in the world frame．

### Before and After Simplification

Previously, this required calculating the differential transformation ( $`\mathbf{C}_{\text{diff}} = \mathbf{C}_{\text{target}} \times \mathbf{C}_{\text{internal}}^{-1}`$ ) and manually handling safe copies to prevent side effects:

**Before:**

```lisp
(setq target-wcoords (send *target-object* :target-frame :copy-worldcoords))
(setq tool-ref-wcoords (send *tool-body* :reference-frame :copy-worldcoords))
(setq diff-coords (send target-wcoords :transform (send tool-ref-wcoords :inverse-transformation)))
(send *tool-body* :transform diff-coords :world)
```

**After:**

With the introduction of the new `:align-to` method, this operation can be written as:

```lisp
(send *tool-body* :align-to (send *tool-body* :reference-frame :copy-worldcoords) (send *target-object* :target-frame representative))
```