### PR TITLE
loadelf.c: Fix dlsym symbol conflict with system libraries on macOS

### DIFF
--- a/lisp/c/loadelf.c
+++ b/lisp/c/loadelf.c
@@ -166,10 +166,11 @@ pointer initnames;
   module_count=0;
   while (iscons(initnames)) {
     /* printf("%s ", ccar(initnames)->c.str.chars); */
-    initfunc= dlsym(dlhandle, (char *)ccar(initnames)->c.str.chars);
-    if (initfunc==NULL) {
-      sprintf(namebuf,"___%s",ccar(initnames)->c.str.chars);
-      initfunc=dlsym(dlhandle, namebuf);}
+    /* First try with ___ prefix to avoid symbol conflicts with system libraries (e.g., libedit's history) */
+    sprintf(namebuf, "___%s", ccar(initnames)->c.str.chars);
+    initfunc = dlsym(dlhandle, namebuf);
+    if (initfunc == NULL) {
+      initfunc = dlsym(dlhandle, (char *)ccar(initnames)->c.str.chars);}
 
     if (initfunc) {
       /* printf(" ok\n"); */
@@ -218,10 +219,11 @@ pointer *argv;
   if (dlhandle==NULL) error(E_USER,(pointer)"This module was not loaded");
 
   while (iscons(initnames)) {
-    initfunc= dlsym(dlhandle, (char *)ccar(initnames)->c.str.chars);
-    if (initfunc==NULL) {
-      sprintf(namebuf,"___%s",ccar(initnames)->c.str.chars);
-      initfunc=dlsym(dlhandle, namebuf);}
+    /* First try with ___ prefix to avoid symbol conflicts with system libraries */
+    sprintf(namebuf, "___%s", ccar(initnames)->c.str.chars);
+    initfunc = dlsym(dlhandle, namebuf);
+    if (initfunc == NULL) {
+      initfunc = dlsym(dlhandle, (char *)ccar(initnames)->c.str.chars);}
 
     if (initfunc) {
       modname=ccar(initnames);


### PR DESCRIPTION
## Summary
Fix segmentation fault on newer macOS versions (Darwin 25.x / macOS 26).

## Problem
On newer macOS, `dlsym(0, "history")` returns libedit's `history` function instead of EusLisp's `___history` function. This causes a segmentation fault when loading modules during the build process (e.g., when compiling with eusgl).

The issue occurs because:
1. When OpenGL libraries are loaded, libedit gets loaded as a dependency
2. `dlopen(0, RTLD_LAZY|RTLD_GLOBAL)` with `-flat_namespace` makes all loaded library symbols visible
3. `dlsym` finds libedit's `history` before EusLisp's `___history`

## Solution
Reverse the symbol lookup order to first try the `___` prefixed symbol name, then fall back to the raw name. This avoids conflicts with system library symbols.

## Testing
Tested on macOS with Darwin 25.2.0 - eusgl and irteusgl build and run successfully after this fix.