### PR TITLE
ci: Change arm32v5/debian:sid to bookworm

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -93,7 +93,7 @@ jobs:
         include:
           - DOCKER_IMAGE: arm64v8/ubuntu:jammy
           - DOCKER_IMAGE: arm64v8/ubuntu:noble
-          - DOCKER_IMAGE: arm32v5/debian:sid
+          - DOCKER_IMAGE: arm32v5/debian:bookworm
           - DOCKER_IMAGE: arm32v7/debian:sid
           - DOCKER_IMAGE: arm64v8/debian:sid
       fail-fast: false


### PR DESCRIPTION
## Summary
Change arm32v5 Docker image from debian:sid to debian:bookworm.

## Problem
Debian Sid (unstable) has dropped support for the armel architecture.
The CI job `linux-arm (arm32v5/debian:sid)` fails with:

```
N: Skipping acquire of configured file 'main/binary-armel/Packages' as repository 
   'http://deb.debian.org/debian sid InRelease' doesn't support architecture 'armel'
E: Unable to locate package sudo
```

## Solution
Use Debian Bookworm (stable) which still supports the armel architecture.